### PR TITLE
fix: launch safety when outsideSqlMap.dfprop does not exist.

### DIFF
--- a/src/main/java/org/dbflute/intro/app/logic/client/ClientInfoLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/client/ClientInfoLogic.java
@@ -229,6 +229,11 @@ public class ClientInfoLogic {
     //                                            ----------
     private OutsideSqlMap prepareOutsideSqlMap(Map<String, Map<String, Object>> dfpropMap) {
         final Map<String, Object> dataMap = dfpropMap.get("outsideSqlMap.dfprop");
+        // If outsideSqlMap.dfprop does not exist, it returns null, because it is not required.
+        if (dataMap == null) {
+            return null;
+        }
+
         final OutsideSqlMap outsideSqlMap = new OutsideSqlMap();
         outsideSqlMap.setGenerateProcedureParameterBean(Boolean.parseBoolean((String) dataMap.get("isGenerateProcedureParameterParam")));
         outsideSqlMap.setProcedureSynonymHandlingType((String) dataMap.get("procedureSynonymHandlingType"));

--- a/src/main/java/org/dbflute/intro/app/web/client/ClientRowResult.java
+++ b/src/main/java/org/dbflute/intro/app/web/client/ClientRowResult.java
@@ -82,8 +82,7 @@ public class ClientRowResult {
         public Boolean checkDbCommentDiff;
         @Required
         public Boolean checkProcedureDiff;
-        @Required
-        public Boolean generateProcedureParameterBean;
+        public Boolean generateProcedureParameterBean; // If outsideSqlMap.dfprop does not exist, this property is null.
         public String procedureSynonymHandlingType;
     }
 


### PR DESCRIPTION
fix [it](https://github.com/dbflute/dbflute-intro/issues/131).