### PR TITLE
Additional fixes in Release/0.3.11

### DIFF
--- a/src/main/java/org/dbflute/intro/app/logic/exception/DirNotFoundException.java
+++ b/src/main/java/org/dbflute/intro/app/logic/exception/DirNotFoundException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 package org.dbflute.intro.app.logic.exception;
 
 /**


### PR DESCRIPTION
I tried to build it after merging the PR for release, but I couldn't.
The reason was that there were classes that didn't have copywrites.
Fix classes with no copyright.