### PR TITLE
feature/#296 mavenCentral からライブラリをダウンロードするように修正

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@
 //                                                                           =============
 buildscript {
     repositories {
-        jcenter() // http://jcenter.bintray.com/
+        mavenCentral()
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3350,11 +3350,6 @@
         "node-pre-gyp": "^0.12.0"
       },
       "dependencies": {
-        "detect-libc": {
-          "version": "1.0.3",
-          "resolved": false,
-          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
-        },
         "semver": {
           "version": "5.7.0",
           "resolved": false,


### PR DESCRIPTION
jcenter経由でのライブラリダウンロードができなくなっても、以下が実行可能なことを確認しました
```
$ rm -rf ~/.gradle/caches
$ ./gradlew build
```