### PR TITLE
Feature/#295 upgrade java 8 to 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:8
+FROM openjdk:17.0.1-jdk-oraclelinux7
 
 COPY entrypoint.sh /entrypoint.sh
 COPY build/libs/dbflute-intro.jar /dbflute-intro.jar


### PR DESCRIPTION
## Issue 
#295 

## やったこと
ベースイメージを OpenJDKの最新に変更
https://hub.docker.com/layers/openjdk/library/openjdk/17.0.1-jdk-oraclelinux7/images/sha256-548e24517873a1402ab2823c131202f1c43ec3e428709b3f92124659b669dba9?context=explore

## 動作確認
- [ ] dbflute-intro のトップディレクトリで以下のコマンドを実行できること
        `$ docker build . -t dbflute-intro --no-cache`
- [ ] 以下のコマンドで DBFlute Intro が起動すること
        `$ docker run -p 8926:8926 dbflute/dbflute-intro:latest`