### PR TITLE
#305 refactor: scroll when you push Add Statement.

### DIFF
--- a/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form-wrapper.tag
+++ b/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form-wrapper.tag
@@ -7,7 +7,7 @@
   </a>
   <div class="ui divided items segment" show="{ state.showForm }">
     <schema-policy-check-statement-form
-      ref="statementForm"
+      ref="statementFormComponent"
       projectName="{ props.projectName }"
       type="{ props.formType }"
       onRegisterSuccess="{ props.onRegisterSuccess }"
@@ -34,8 +34,10 @@
     self.toggleForm = () => {
       self.state.showForm = !self.state.showForm
       self.update()
+      // フォームが表示されていればスクロールする
+      // DOM要素を参照する必要があるため、画面更新(self.update())の完了を待ってから行う必要があることに注意
       if (self.state.showForm) {
-        self.refs.statementForm.scrollToTop()
+        self.refs.statementFormComponent.scrollToTop()
       }
     }
   </script>

--- a/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form-wrapper.tag
+++ b/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form-wrapper.tag
@@ -7,6 +7,7 @@
   </a>
   <div class="ui divided items segment" show="{ state.showForm }">
     <schema-policy-check-statement-form
+      ref="statementForm"
       projectName="{ props.projectName }"
       type="{ props.formType }"
       onRegisterSuccess="{ props.onRegisterSuccess }"
@@ -33,6 +34,9 @@
     self.toggleForm = () => {
       self.state.showForm = !self.state.showForm
       self.update()
+      if (self.state.showForm) {
+        self.refs.statementForm.scrollToTop()
+      }
     }
   </script>
 </schema-policy-check-statement-form-wrapper>

--- a/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form.tag
+++ b/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form.tag
@@ -1,5 +1,5 @@
 <schema-policy-check-statement-form>
-  <form class="ui large form">
+  <form ref="statementForm" class="ui large form">
     <div class="field">
       <label>Preview</label>
       <div class="ui inverted segment">
@@ -94,7 +94,7 @@
     </div>
 
     <div class="grouped fields required">
-      
+
       <schema-policy-check-statement-form-expected
         formtype="{ opts.type }"
         handlefieldadd="{ handleExpectedFieldAdd }"
@@ -180,6 +180,10 @@
 
     this.toggleExpectedHelp = () => {
       self.refs.expectedhelp.toggle()
+    }
+
+    this.scrollToTop = () => {
+      self.refs.statementForm.scrollIntoView({ behavior: 'smooth' })
     }
 
     self.statement = {

--- a/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form.tag
+++ b/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form.tag
@@ -182,7 +182,11 @@
       self.refs.expectedhelp.toggle()
     }
 
+    /**
+     * フォームを入力しやすい位置に画面をスクロールする
+     */
     this.scrollToTop = () => {
+      // statementFormは標準のformタグなので, 標準APIのscrollIntoViewを呼び出せる
       self.refs.statementForm.scrollIntoView({ behavior: 'smooth' })
     }
 


### PR DESCRIPTION
## Issue 
#305  

## やったこと
- Statementフォームを開いた際、スクロールするようにした

## 動作確認
### 前提
- schema-policy設定画面の `Table Schema Policy` または `Column Schema Policy` タブを開いている
### テストケース
- [x] フォームが閉じた状態で `Add Statement` リンクを押下
  - → フォームが開き、フォームの先頭にスクロールすること（画面の高さが足りていない場合はフォームのsubmitボタンが一番に下に来た状態にスクロールすること）
- [x] フォームが開いた状態で  `Hide Form` リンクを押下
  - → フォームが閉じること
