### PR TITLE
#305 refactor: Statementの登録に成功した際にフィードバックを追加

### DIFF
--- a/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form-wrapper.tag
+++ b/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form-wrapper.tag
@@ -59,7 +59,7 @@
     }
 
     /**
-     * フォームを閉じる
+     * フォームを閉じる (現在の開閉状態に関わらず非表示にする)
      */
     self.closeForm = () => {
       self.state.showForm = false

--- a/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form-wrapper.tag
+++ b/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form-wrapper.tag
@@ -10,7 +10,7 @@
       ref="statementFormComponent"
       projectName="{ props.projectName }"
       type="{ props.formType }"
-      onRegisterSuccess="{ props.onRegisterSuccess }"
+      onRegisterSuccess="{ onRegisterSuccess }"
     />
   </div>
 
@@ -31,6 +31,23 @@
       self.update()
     })
 
+    /**
+     * 登録が成功したときのコールバック処理
+     * - フォームを閉じて、成功トーストを表示することでユーザーにフィードバックをする
+     */
+    self.onRegisterSuccess = () => {
+      self.closeForm()
+      self.successToast({
+        title: 'Create statement completed',
+        message: 'statement was successfully created!!',
+      })
+      self.props.onRegisterSuccess()
+    }
+
+    /**
+     * フォームの開閉状態を切り替える
+     * - 開く場合はフォームが表示される位置までスクロールする
+     */
     self.toggleForm = () => {
       self.state.showForm = !self.state.showForm
       self.update()
@@ -39,6 +56,14 @@
       if (self.state.showForm) {
         self.refs.statementFormComponent.scrollToTop()
       }
+    }
+
+    /**
+     * フォームを閉じる
+     */
+    self.closeForm = () => {
+      self.state.showForm = false
+      self.update()
     }
   </script>
 </schema-policy-check-statement-form-wrapper>

--- a/src/static/app/client/create.tag
+++ b/src/static/app/client/create.tag
@@ -184,10 +184,9 @@
       }
     }
     this.showToast = (projectName) => {
-      this.suToast({
+      this.successToast({
         title: 'Create task completed',
         message: 'Client for project \'' + projectName + '\', was successfully created!!',
-        class: 'pink positive'
       })
     }
 

--- a/src/static/app/index.js
+++ b/src/static/app/index.js
@@ -47,6 +47,11 @@ import './error/404.tag'
 
 global.route = route;
 global.observable = riot.observable();
+/*
+ * グローバルミックスインの登録
+ * https://v3.riotjs.vercel.app/ja/api/#ミックスイン
+ * mixinはriotのmountより前に実施する必要あり
+ */
 riot.mixin(ToastMixin);
 riot.mount('*')
 

--- a/src/static/app/index.js
+++ b/src/static/app/index.js
@@ -9,6 +9,8 @@ import i18n from 'riot-i18nlet'
 import i18n_ja from '../assets/i18n/locale-ja.json'
 import i18n_en from '../assets/i18n/locale-en.json'
 
+import ToastMixin from './mixin/ToastMixin';
+
 import './main/main.tag'
 import './client/create.tag'
 import './client/client.tag'
@@ -46,6 +48,7 @@ import './error/404.tag'
 global.route = route;
 global.observable = riot.observable();
 riot.mount('*')
+riot.mixin(ToastMixin);
 
 /**
  * ffetch for API access

--- a/src/static/app/index.js
+++ b/src/static/app/index.js
@@ -47,8 +47,8 @@ import './error/404.tag'
 
 global.route = route;
 global.observable = riot.observable();
-riot.mount('*')
 riot.mixin(ToastMixin);
+riot.mount('*')
 
 /**
  * ffetch for API access

--- a/src/static/app/mixin/ToastMixin.js
+++ b/src/static/app/mixin/ToastMixin.js
@@ -1,0 +1,17 @@
+const ToastMixin = {
+  /**
+   * 成功時のトーストを表示する
+   * - 使用できるパラメータは[semantic-ui-riotのtoast]{@link https://semantic-ui-riot.web.app/addon/toast}を参照
+   * @param {string|null} title タイトル（未設定の場合は省略される）
+   * @param {string|null} message メッセージ（未設定の場合は省略される）
+   */
+  successToast({title= null, message= null}) {
+    this.suToast({
+      title, // keyと渡す変数名が同じため省略する ("title: title,"としているのと同じ)
+      message, // keyと渡す変数名が同じため省略する ("message: message,"としているのと同じ)
+      class: 'pink positive'
+    })
+  }
+}
+
+export default ToastMixin

--- a/src/static/app/welcome/welcome.tag
+++ b/src/static/app/welcome/welcome.tag
@@ -38,7 +38,7 @@
             <input type="text" ref="packageBase" value="org.docksidestage.dbflute" />
           </div>
         </div>
-      </div>        
+      </div>
       <div class="row">
         <div class="column">
           <div class="required field">
@@ -181,10 +181,9 @@
       }
     }
     this.showToast = (projectName) => {
-      this.suToast({
+      this.successToast({
         title: 'Create task completed',
         message: 'Client for project \'' + projectName + '\', was successfully created!!',
-        class: 'pink positive'
       })
     }
 


### PR DESCRIPTION
## Issue 
#305  

## やったこと
- Statementの登録に成功した際にフィードバックを追加
  - フォームを閉じる
  - トーストを出す

## 動作確認
### 前提
- schema-policy設定画面の `Table Schema Policy` または `Column Schema Policy` タブを開いている
### テストケース
- [x] フォームを開きStatementを追加する
  - → フォームが閉じ、トーストメッセージが画面右上に表示されること
