### PR TITLE
Feature/#278 fix behavior after addition

### DIFF
--- a/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form-expected.tag
+++ b/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form-expected.tag
@@ -52,12 +52,14 @@
         <div class="inline fields" style="float: right" show="{ needsCondition() }">
           <div class="field">
             <div class="ui radio checkbox">
+              <!-- checkedの制御はすべて関数側で行うので、ここでは定義しない -->
               <input type="radio" name="expected-mode" ref="isAnd" onchange="{ handleConditionChange }">
               <label>and</label>
             </div>
           </div>
           <div class="field">
             <div class="ui radio checkbox">
+              <!-- checkedの制御はすべて関数側で行うので、ここでは定義しない -->
               <input type="radio" name="expected-mode" ref="isOr" onchange="{ handleConditionChange }">
               <label>or</label>
             </div>

--- a/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form-expected.tag
+++ b/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form-expected.tag
@@ -139,6 +139,12 @@
         self.refs.isAnd.checked = true // as default
       }
     })
+    self.on('update', () => {
+      self.state = {
+        fields: self.opts.fields,
+        condition: self.opts.condition
+      }
+    })
   </script>
 
   <style>

--- a/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form-expected.tag
+++ b/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form-expected.tag
@@ -52,7 +52,7 @@
         <div class="inline fields" style="float: right" show="{ needsCondition() }">
           <div class="field">
             <div class="ui radio checkbox">
-              <input type="radio" name="expected-mode" ref="isAnd" checked="checked" onchange="{ handleConditionChange }">
+              <input type="radio" name="expected-mode" ref="isAnd" onchange="{ handleConditionChange }">
               <label>and</label>
             </div>
           </div>
@@ -81,7 +81,8 @@
 
     self.state = {
       showSample: false,
-      fields: self.opts.fields
+      fields: self.opts.fields,
+      condition: self.opts.condition
     }
 
     self.handleFieldAdd = () => {
@@ -125,6 +126,17 @@
       self.state.showSample = !self.state.showSample
       self.update()
     }
+
+    self.on('mount', () => {
+      const condition = self.state.condition
+      if ('and' === condition) {
+        self.refs.isAnd.checked = true
+      } else if ('or' === condition) {
+        self.refs.isOr.checked = true
+      } else {
+        self.refs.isAnd.checked = true // as default
+      }
+    })
   </script>
 
   <style>

--- a/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form.tag
+++ b/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form.tag
@@ -126,7 +126,6 @@
   <script>
     import { v4 as uuid } from 'uuid'
     import _ApiFactory from '../../../common/factory/ApiFactory'
-    const riot = require('riot')
 
     const ApiFactory = new _ApiFactory()
     let self = this

--- a/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form.tag
+++ b/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form.tag
@@ -261,6 +261,8 @@
      * Expected の入力フォームをこの tag の state の値で反映させる
      */
     self.reflectExpectedField = () => {
+      // 改めてマウントしなおさなければ、親タグにある "self.state" の値が変更されても、
+      // 子タグが追従して画面に表示しているコンポーネントを更新されなくなってしまう
       riot.mount('schema-policy-check-statement-form-expected', {
         formtype: self.opts.type,
         handlefieldadd: self.handleExpectedFieldAdd,

--- a/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form.tag
+++ b/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form.tag
@@ -242,7 +242,7 @@
         subjectVerb: null,
         complement: ''
       })
-      self.refrectExpectedField()
+      self.reflectExpectedField()
       self.update()
     }
 
@@ -260,7 +260,7 @@
     /**
      * Expected の入力フォームをこの tag の state の値で反映させる
      */
-    self.refrectExpectedField = () => {
+    self.reflectExpectedField = () => {
       riot.mount('schema-policy-check-statement-form-expected', {
         formtype: self.opts.type,
         handlefieldadd: self.handleExpectedFieldAdd,
@@ -287,7 +287,7 @@
         }],
         condition: 'and' // or 'or'
       }
-      self.refrectExpectedField()
+      self.reflectExpectedField()
       self.update()
     }
 

--- a/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form.tag
+++ b/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form.tag
@@ -126,6 +126,7 @@
   <script>
     import { v4 as uuid } from 'uuid'
     import _ApiFactory from '../../../common/factory/ApiFactory'
+    const riot = require('riot')
 
     const ApiFactory = new _ApiFactory()
     let self = this
@@ -241,6 +242,8 @@
         subjectVerb: null,
         complement: ''
       })
+      self.refrectExpectedField()
+      self.update()
     }
 
     this.handleExpectedFieldDelete = (id) => {
@@ -254,6 +257,24 @@
       self.update()
     }
 
+    /**
+     * Expected の入力フォームをこの tag の state の値で反映させる
+     */
+    self.refrectExpectedField = () => {
+      riot.mount('schema-policy-check-statement-form-expected', {
+        formtype: self.opts.type,
+        handlefieldadd: self.handleExpectedFieldAdd,
+        handlefieldchange: self.handleExpectedFieldChange,
+        handlefielddelete: self.handleExpectedFieldDelete,
+        handleconditionchange: self.handleExpectedConditionChange,
+        fields: self.state.expected.fields,
+        condition: self.state.expected.condition,
+      })
+    }
+
+    /**
+    * Add Statement フォームの各フィールドの値を初期表示に戻す
+    */
     this.cleanInput = () => {
       self.statement.clean()
       self.refs.subject.value = ''
@@ -266,6 +287,7 @@
         }],
         condition: 'and' // or 'or'
       }
+      self.refrectExpectedField()
       self.update()
     }
 

--- a/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form.tag
+++ b/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form.tag
@@ -273,8 +273,8 @@
     }
 
     /**
-    * Add Statement フォームの各フィールドの値を初期表示に戻す
-    */
+     * Add Statement フォームの各フィールドの値を初期表示に戻す
+     */
     this.cleanInput = () => {
       self.statement.clean()
       self.refs.subject.value = ''

--- a/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form.tag
+++ b/src/static/app/client/client-content/schema-policy-check/schema-policy-check-statement-form.tag
@@ -242,7 +242,6 @@
         subjectVerb: null,
         complement: ''
       })
-      self.reflectExpectedField()
       self.update()
     }
 
@@ -255,23 +254,6 @@
     this.handleExpectedConditionChange = (condition) => {
       self.state.expected.condition = condition
       self.update()
-    }
-
-    /**
-     * Expected の入力フォームをこの tag の state の値で反映させる
-     */
-    self.reflectExpectedField = () => {
-      // 改めてマウントしなおさなければ、親タグにある "self.state" の値が変更されても、
-      // 子タグが追従して画面に表示しているコンポーネントを更新されなくなってしまう
-      riot.mount('schema-policy-check-statement-form-expected', {
-        formtype: self.opts.type,
-        handlefieldadd: self.handleExpectedFieldAdd,
-        handlefieldchange: self.handleExpectedFieldChange,
-        handlefielddelete: self.handleExpectedFieldDelete,
-        handleconditionchange: self.handleExpectedConditionChange,
-        fields: self.state.expected.fields,
-        condition: self.state.expected.condition,
-      })
     }
 
     /**
@@ -289,7 +271,6 @@
         }],
         condition: 'and' // or 'or'
       }
-      self.reflectExpectedField()
       self.update()
     }
 


### PR DESCRIPTION
## Issue
#278 

## やったこと
- expected の input に関するバグを修正
   - https://github.com/dbflute/dbflute-intro/issues/278#issuecomment-984580583
- or のまま + を押すと and に戻るバグ を修正

## 動作確認
SchemaPolicyCheck の設定フォームの Expected の項目について

### expected の input に関するバグを修正
- [ ] 1度目の「Add」ができること
- [ ] 続けて、expected のフォームを `+` ボタンで2つに増やし、2度目の「Add」ができること
- [ ] 続けて、expected のフォームを `+` ボタンで3つに増やし、3度目の「Add」ができること

### or のまま + を押すと and に戻るバグ を修正
- [ ] expected のフォームを `+` ボタンで2つに増やせること　
- [ ] expected の condition を `or` に変更できること
- [ ] expected のフォームを `+` ボタンで3つに増やしたとき、condition が `or` のままであること
- [ ] expected のフォームを `x` ボタンで2つに減らしたとき、condition が `or` のままであること

その他モンキー気味に