### PR TITLE
#373 disable_start_deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,8 +76,8 @@ workflows:
       - notify_result:
           requires:
             - test_and_build
-      - ★ start_deploy:
-          type: approval
-          requires:
-            - test_and_build
+      # - ★ start_deploy:
+      #     type: approval
+      #     requires:
+      #       - test_and_build
 


### PR DESCRIPTION
普段動かしていないので、コメントアウト

PRが CI が終わってないような見た目なので、、、
テストが通っていたら黄色い○じゃなくて、緑色の✓が出るようにしたい

![スクリーンショット 2022-02-26 12 33 06](https://user-images.githubusercontent.com/12844158/155827342-6bac2cbe-deb8-4125-a57b-5c205d393653.png)

