### PR TITLE
#370 riot6に向けた既存コードのコメント追加: メニューと routing 系

### DIFF
--- a/src/static/app/client/client-menu.tag
+++ b/src/static/app/client/client-menu.tag
@@ -1,8 +1,8 @@
 <client-menu>
-  <!--
+  <!-- DBFlute Intro のクライアント画面で表示される左側メニュー  (written at 2022/03/10)
     機能:
       o DBFlute Intro 画面全体の左側のメニュー
-        o のうち、クライアントが選択されているときに表示されるもの
+      o のうち、クライアントが選択されているときに表示されるもの
 
       作りの特徴:
       o 現在選択されているメニューの情報を親から受け取り、active かどうかを判断している
@@ -98,10 +98,10 @@
      * この変更に対応して、index.js の処理により、tagのマウントのされ方が変わる
      * @param menuType {string} URLで指定されるメニュータイプ e.g. "execute", "settings", "files" (NotNull)
      * @param menuName {string} URLで指定されるメニュー名 e.g. "documents", "schema-policy-check", and so on... (NotNull)
-     * @see dbflute-intro/src/static/app/index.js@157
+     * @see dbflute-intro/src/static/app/index.js@157 (riot6移行時にコードが移動するかも！？)
      */
     this.goToMenuItem = (menuType, menuName) => {
-      // #thinking rooting に関する情報、探しやすいように切り出してあげたい by cabos (2022/02/26)
+      // #thinking routing に関する情報、探しやすいように切り出してあげたい by cabos (2022/02/26)
       // （ただし大規模な修正になるので今やることではない）
       route(`client/${this.opts.projectName}/${menuType}/${menuName}`)
     }

--- a/src/static/app/client/client-menu.tag
+++ b/src/static/app/client/client-menu.tag
@@ -87,6 +87,7 @@
      * 親から選択されている clientMenuType, clientMenuName を受け取り、メニューの行が、active かどうかを判断している
      * @param menuType {string} URLで指定されるメニュータイプ e.g. "execute", "settings", "files" (NotNull)
      * @param menuName {string} URLで指定されるメニュー名 e.g. "documents", "schema-policy-check", and so on... (NotNull)
+     * @return {boolean} 現在選択されているメニューであれば true (NotNull)
      */
     this.isActiveItem = (menuType, menuName) => {
       return menuType === this.opts.clientMenuType && menuName === this.opts.clientMenuName

--- a/src/static/app/client/client-menu.tag
+++ b/src/static/app/client/client-menu.tag
@@ -1,9 +1,39 @@
 <client-menu>
+  <!--
+    機能:
+      o DBFlute Intro 画面全体の左側のメニュー
+        o のうち、クライアントが選択されているときに表示されるもの
+
+      作りの特徴:
+      o 現在選択されているメニューの情報を親から受け取り、active かどうかを判断している
+      o メニューをクリックしたとき、URLを書き換えている
+  -->
   <div class="ui left fixed small inverted vertical menu">
+
+    <!-- メニューの一番上に表示されている「DBFlute Intro」の文字列 -->
     <menu-home></menu-home>
+    
+    <!--
+      このタグの簡略図は下記
+
+      Execute
+      |- Documents
+      |- Schema Policy Check
+      |- Schema Sync Check
+      |- Replace Schema
+      |- Alter Check
+
+      General Settings
+      |- Database Info
+
+      Files
+      |- Logs
+    -->
     <div class="item">
       <div class="header">Execute</div>
       <div class="ui tiny inverted vertical menu">
+        <!-- 選択されていたら active というクラス名がつく、太字で目立って表示される -->
+        <!-- このaタグが押されたとき、URLが変わる -->
         <a class="{ 'active': isActiveItem('execute', 'documents') } item"
            onclick="{ goToMenuItem.bind(this, 'execute', 'documents') }">
           Documents
@@ -45,16 +75,33 @@
       </div>
     </div>
   </div>
+
   <style>
     .ui.tiny.inverted.vertical.menu {
       margin-left: 0px;
     }
   </style>
+
   <script>
+    /**
+     * 親から選択されている clientMenuType, clientMenuName を受け取り、メニューの行が、active かどうかを判断している
+     * @param menuType {string} URLで指定されるメニュータイプ e.g. "execute", "settings", "files" (NotNull)
+     * @param menuName {string} URLで指定されるメニュー名 e.g. "documents", "schema-policy-check", and so on... (NotNull)
+     */
     this.isActiveItem = (menuType, menuName) => {
       return menuType === this.opts.clientMenuType && menuName === this.opts.clientMenuName
     }
+
+    /**
+     * URLを変更する
+     * この変更に対応して、index.js の処理により、tagのマウントのされ方が変わる
+     * @param menuType {string} URLで指定されるメニュータイプ e.g. "execute", "settings", "files" (NotNull)
+     * @param menuName {string} URLで指定されるメニュー名 e.g. "documents", "schema-policy-check", and so on... (NotNull)
+     * @see dbflute-intro/src/static/app/index.js@157
+     */
     this.goToMenuItem = (menuType, menuName) => {
+      // #thinking rooting に関する情報、探しやすいように切り出してあげたい by cabos (2022/02/26)
+      // （ただし大規模な修正になるので今やることではない）
       route(`client/${this.opts.projectName}/${menuType}/${menuName}`)
     }
   </script>

--- a/src/static/app/client/client-menu.tag
+++ b/src/static/app/client/client-menu.tag
@@ -2,6 +2,7 @@
   <!-- DBFlute Intro のクライアント画面で表示される左側メニュー  (written at 2022/03/10)
     機能:
       o DBFlute Intro 画面全体の左側のメニュー
+      o urlだと、「#client/${clientName}/*」に当たる画面
       o のうち、クライアントが選択されているときに表示されるもの
 
       作りの特徴:

--- a/src/static/app/client/client.tag
+++ b/src/static/app/client/client.tag
@@ -1,5 +1,5 @@
 <client>
-  <!--
+  <!-- DBFlute Intro のクライアント画面のメニュー以外の部分 (written at 2022/03/10)
     機能:
       o DBFluteのクライアント機能全般を提供する
       o この tag で実施しているのは、どの機能を表示するのか切り替えることだけ
@@ -60,7 +60,7 @@
       const menuType = this.opts.clientMenuType
       const menuName = this.opts.clientMenuName
 
-      // #thinking 実質 rooting に関する情報、探しやすいように切り出してあげたい  by cabos (2022/02/26)
+      // #thinking 実質 routing に関する情報、探しやすいように切り出してあげたい  by cabos (2022/02/26)
       // （ただし大規模な修正になるので今やることではない）
       if (menuType === 'execute' && menuName === 'documents') {
         // tagName に入れる文字列は、client-content ディレクトリ配下のtag名から拡張子を抜いたものと一致している

--- a/src/static/app/client/client.tag
+++ b/src/static/app/client/client.tag
@@ -84,6 +84,7 @@
         riot.mount('client-content', tagName, { projectName: this.opts.projectName, client: this.client })
       }
       // #thinking 存在しない tagName が入っていた場合って静かに何も表示されなくなるけど、それでいいんだっけ？ by cabos (2022/02/26)
+      // https://github.com/dbflute/dbflute-intro/pull/377#discussion_r823736935
     }
   </script>
 </client>

--- a/src/static/app/client/client.tag
+++ b/src/static/app/client/client.tag
@@ -2,6 +2,7 @@
   <!-- DBFlute Intro のクライアント画面のメニュー以外の部分 (written at 2022/03/10)
     機能:
       o DBFluteのクライアント機能全般を提供する
+      o urlだと、「#client/${clientName}/*」に当たる画面
       o この tag で実施しているのは、どの機能を表示するのか切り替えることだけ
 
       作りの特徴:
@@ -82,7 +83,7 @@
         // まるっと、<client-content></client-content> の中身を差し替えている
         riot.mount('client-content', tagName, { projectName: this.opts.projectName, client: this.client })
       }
-      // #thinking 存在しない tagName が入っていた場合ってどうなるんだっけ？ by cabos (2022/02/26)
+      // #thinking 存在しない tagName が入っていた場合って静かに何も表示されなくなるけど、それでいいんだっけ？ by cabos (2022/02/26)
     }
   </script>
 </client>

--- a/src/static/app/client/client.tag
+++ b/src/static/app/client/client.tag
@@ -1,11 +1,25 @@
 <client>
+  <!--
+    機能:
+      o DBFluteのクライアント機能全般を提供する
+      o この tag で実施しているのは、どの機能を表示するのか切り替えることだけ
+
+      作りの特徴:
+      o tag の切り替えは、親から渡される "clientMenuType", "clientMenuName" を元にしている
+      o 豪快に mount している
+  -->
+
   <h1>DBFlute Client { opts.projectName }</h1>
     <!-- hide for_now, not important and should be designed more by jflute (2020/09/28)
     <p>for { client.databaseCode }, { client.languageCode }, { client.containerCode }</p>
      -->
+
+  <!-- クライアント画面がマウントされるところ -->
+  <!-- script tag の中のコードを読むとわかるが、豪快に書き換えていいる -->
   <client-content></client-content>
 
   <script>
+    // #thinking import 文に揃えてあげたい  by cabos (2022/02/26)
     let riot = require('riot')
     import _ApiFactory from '../common/factory/ApiFactory.js'
 
@@ -16,24 +30,40 @@
     // ===================================================================================
     //                                                                          Initialize
     //                                                                          ==========
+    /**
+     * マウント時に呼び出される処理
+     */
     this.on('mount', () => {
       self.prepareCurrentProject(self.opts.projectName)
     })
 
+    /**
+     * この tag の準備を行う
+     * o サーバからプロジェクトに関する情報を取得して、内部に保持する
+     * o 豪快に必要な画面をまるっと mount する
+     */
     this.prepareCurrentProject = () => {
       ApiFactory.clientPropbase(self.opts.projectName).then((response) => {
         self.client = response
+        // この中が豪快
         self.mountClientContent()
         self.update()
       })
     }
 
+    /**
+     * 親から opts 経由で渡される clientMenuType, clientMenuName を元にどの tag を mount するのかを判断し
+     * <client-content></client-content> の部分に豪快に mount する
+     */
     this.mountClientContent = () => {
       let tagName = null
       const menuType = this.opts.clientMenuType
       const menuName = this.opts.clientMenuName
 
+      // #thinking 実質 rooting に関する情報、探しやすいように切り出してあげたい  by cabos (2022/02/26)
+      // （ただし大規模な修正になるので今やることではない）
       if (menuType === 'execute' && menuName === 'documents') {
+        // tagName に入れる文字列は、client-content ディレクトリ配下のtag名から拡張子を抜いたものと一致している
         tagName = 'ex-documents'
       } else if (menuType === 'execute' && menuName === 'schema-sync-check') {
         tagName = 'ex-schema-sync-check'
@@ -49,8 +79,10 @@
         tagName = 'fl-logs'
       }
       if (tagName) {
+        // まるっと、<client-content></client-content> の中身を差し替えている
         riot.mount('client-content', tagName, { projectName: this.opts.projectName, client: this.client })
       }
+      // #thinking 存在しない tagName が入っていた場合ってどうなるんだっけ？ by cabos (2022/02/26)
     }
   </script>
 </client>

--- a/src/static/app/common/common-menu.tag
+++ b/src/static/app/common/common-menu.tag
@@ -1,5 +1,5 @@
 <common-menu>
-  <!--
+  <!-- DBFlute Intro のクライアント選択画面のメニュー以外の部分 (written at 2022/03/10)
     機能:
       o DBFlute Intro 画面全体の左側のメニュー
         o のうち、クライアントが選択されて無いときに表示されるもの

--- a/src/static/app/common/common-menu.tag
+++ b/src/static/app/common/common-menu.tag
@@ -1,6 +1,20 @@
 <common-menu>
+  <!--
+    機能:
+      o DBFlute Intro 画面全体の左側のメニュー
+        o のうち、クライアントが選択されて無いときに表示されるもの
+      o DBFlute のドキュメントへのリンクになっている
+
+      作りの特徴:
+      o 特に logic は持っていない
+  -->
+  <!-- #thinking common ってほど common で使われいてる tag でもなくない！？ by cabos (2022/02/26) -->
   <div class="ui left fixed small inverted vertical menu">
+
+    <!-- メニューの一番上に表示されている「DBFlute Intro」の文字列 -->
     <menu-home></menu-home>
+
+    <!-- リンク --> 
     <a class="item" href="http://dbflute.seasar.org/ja/manual/function/generator/intro/" target="_blank">Intro's Document Page</a>
     <a class="item" href="http://github.com/dbflute/dbflute-intro" target="_blank">Intro's Github Page</a>
     <a class="item" href="http://dbflute.seasar.org/" target="_blank">DBFlute Top Page</a>

--- a/src/static/app/common/common-menu.tag
+++ b/src/static/app/common/common-menu.tag
@@ -1,8 +1,7 @@
 <common-menu>
-  <!-- DBFlute Intro のクライアント選択画面のメニュー以外の部分 (written at 2022/03/10)
+  <!-- 初期設定済み DBFlute Intro のトップ画面のメニュー部分 (written at 2022/03/10)
     機能:
-      o DBFlute Intro 画面全体の左側のメニュー
-        o のうち、クライアントが選択されて無いときに表示されるもの
+      o 初期設定済み DBFlute Intro のトップ画面の左側のメニュー
       o DBFlute のドキュメントへのリンクになっている
 
       作りの特徴:


### PR DESCRIPTION
コメント追加なので、コメントを読んで把握しながら「あれ？」って思ったところにコメントください。

3月12日までに見てもらえると嬉しいです

---
下記コードも参考にしながらだと、より理解がスムーズかもしれません
一番上の、URLをもとに、どのタグを読み込むのか、どのような値を opts で渡すのかを制御するコードです
dbflute-intro/src/static/app/index.jsindex.js @135 ~
```javascript
// ===================================================================================
//                                                               Routing (URL mapping)
//                                                               =====================
route(() => {
  riot.mount('side-menu', 'common-menu')
  riot.mount('content', 'main')
})
route('', () => {
  riot.mount('side-menu', 'common-menu')
  riot.mount('content', 'main')
})

// client entry URL from main page
// e.g. #client/maihamadb/ to #client/maihamadb/execute/documents
route('client/*', projectName => {
  const opts = { projectName, clientMenuType: 'execute', clientMenuName: 'documents' }
  riot.mount('side-menu', 'client-menu', opts)
  riot.mount('content', 'client', opts)
})

// client basic page as /{projectName}/{menuType}/{menuName}
// e.g. #client/maihamadb/execute/documents
route('client/*/*/*', (projectName, clientMenuType, clientMenuName) => {
  const opts = { projectName, clientMenuType, clientMenuName }
  riot.mount('side-menu', 'client-menu', opts)
  riot.mount('content', 'client', opts)
})

```