### PR TITLE
Feature/#406 classes コマンドのトリガーを削除し、release コマンドを作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ http://dbflute.seasar.org/ja/manual/function/generator/intro/index.html
 ## How to refresh application
 1. $ `./gradlew refresh`
 
-## How to build
-1. `$ ./gradlew build`
-2. `$ java -jar build/libs/dbflute-intro.jar`
+## How to build production ready jar file
+1. `$ ./gradlew release`
+1. `$ java -jar build/libs/dbflute-intro.jar # for jar file check` 
 
 ## Server-side Framework
 

--- a/build.gradle
+++ b/build.gradle
@@ -189,3 +189,12 @@ tasks['refreshResourceAfter'].dependsOn('refreshResource')
 if (tasks.findByName('eclipseClasspath')) {
     tasks['eclipseClasspath'].dependsOn('refreshResource')
 }
+
+// =======================================================================================
+//                                                                                 Release
+//                                                                                 =======
+// フロントエンドのビルド -> バックエンドのビルド -> jar ファイルの作成の順番でリリース物を作成する
+tasks['build'].mustRunAfter('npm_run_build')
+tasks['build'].mustRunAfter('manifest')
+tasks['build'].mustRunAfter('cacheKey')
+task release(dependsOn: ['build', 'manifest', 'cacheKey', 'npm_run_build'])

--- a/gradle/gradlePlugin/frontend.gradle
+++ b/gradle/gradlePlugin/frontend.gradle
@@ -55,6 +55,7 @@ task cacheKey(dependsOn: npm_run_build) << {
     file('dist/cacheKey.json').text = json.toString()
 }
 
+// #thinking riot6化に合わせて、フロントエンドの出力先が変わってたらここも修正が必要 by cabos
 task cleanDist() {
     def fileList = file('./dist/').listFiles()
     if (fileList != null) {
@@ -62,12 +63,15 @@ task cleanDist() {
     }
 }
 
+// #thinking riot6の場合、gradle経由でリソースのコピーはしないようにして、このコードを消したい by cabos
 task copyStaticResource(type: Copy) {
   from fileTree(dir: file('src/static'), includes: ["index.html", "favicon.ico", "**/index.css", "assets/**", "image/**"])
   into 'dist/'
 }
 
-['classes' : ['npm_run_build', 'manifest', 'cacheKey'], 'clean' : 'npm_cache_clean', 'npm_run_build' : ['cleanDist', 'copyStaticResource']].each {
+// gradle 経由で npm コマンドが実行されるのは主にjarファイルを固める場合のみ
+// jarファイルを固める前には、念の為フロントの成果物を消して作り直す
+['npm_run_build' : ['cleanDist', 'copyStaticResource']].each {
     if (!tasks.findByName(it.key)) {
         task(it.key) {
           // If task not exists, define empty task.
@@ -75,5 +79,3 @@ task copyStaticResource(type: Copy) {
     }
     tasks[it.key].dependsOn(it.value)
 }
-
-tasks['refreshResource'].dependsOn('npmInstall')


### PR DESCRIPTION
riot6化優先めで、手が空いたときにレビューしてもらえればと思います 🙇‍♂️

## やったこと
- 開発のためのバックエンド起動時に npm コマンドが走らないように修正
   - classes コマンドをトリガーに npm コマンドを実行しないようにした
- リリース時用のコマンドを別で準備、ドキュメントの整備
   - `./gradlew build` -> `./gradlew release` で jar ファイルを作成できるようにした 

## 何が嬉しいか？
- `./gradlew run` を実行するときに、`npm install` の実行を待たなくて良くなる