### PR TITLE
feature/#383 fix indent

### DIFF
--- a/src/static/app/client/latest-result.tag
+++ b/src/static/app/client/latest-result.tag
@@ -98,7 +98,7 @@
      * ログ情報を取得して表示する。
      */
     this.updateLatestResult = () => {
-	  // the response is LogBean.java (2022/05/04)
+      // the response is LogBean.java (2022/05/04)
       ApiFactory.latestResult(self.opts.projectName, self.opts.task).then((response) => {
         if (response.fileName) { // ログファイルがなければempty responseがあり得るのでチェックしている
           // Object.assign(target, source)は、targetの内容をsourceで上書きマージしている


### PR DESCRIPTION
npm run start を実行したときに表示される下記のエラーログへの修正対応

```
WARNING in ./src/static/app/client/latest-result.tag
Module Warning (from ./node_modules/eslint-loader/index.js):

/xxxxxxxxxxxxxxxxxxxs/dbflute/dbflute-intro/src/static/app/client/latest-result.tag
  101:2  error  Mixed spaces and tabs  no-mixed-spaces-and-tabs
```