### PR TITLE
Feature/#418 mysql8.0 のコンテナを立ち上げられるようにする（dbflute-test-dbms-mysql を参考に）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,8 @@ classes/
 /gradle/launch4j/win
 
 # Middleware
-localdb/
+localdb/*
+!localdb/my-docker.cnf
 localap/
 etc/introdb
 etc/testdb

--- a/README.md
+++ b/README.md
@@ -28,11 +28,16 @@ http://dbflute.seasar.org/ja/manual/function/generator/intro/index.html
 2. `$ npm start` => boot FrontEnd Application (Riot)
 
 ## How to refresh application
-1. $ `./gradlew refresh`
+1. `$ ./gradlew refresh`
 
 ## How to build production ready jar file
 1. `$ ./gradlew release`
 1. `$ java -jar build/libs/dbflute-intro.jar # for jar file check` 
+
+## How to prepare containers
+1. `$ docker compose up -d`
+
+See docker-compose.yml for details
 
 ## Server-side Framework
 

--- a/dbflute_trohamadb/dfprop/databaseInfoMap.dfprop
+++ b/dbflute_trohamadb/dfprop/databaseInfoMap.dfprop
@@ -16,7 +16,7 @@
 #
 map:{
 	; driver   = com.mysql.jdbc.Driver
-	; url      = jdbc:mysql://localhost:3306/trohamadb?characterEncoding=UTF-8
+	; url      = jdbc:mysql://localhost:43316/trohamadb?characterEncoding=UTF-8
 	; schema   = 
 	; user     = trohamadb
 	; password = trohamadb

--- a/dbflute_trohamadb/dfprop/replaceSchemaMap.dfprop
+++ b/dbflute_trohamadb/dfprop/replaceSchemaMap.dfprop
@@ -152,7 +152,7 @@ map:{
     #
     ; additionalUserMap = map:{
         ; system = map:{
-            ; url = jdbc:mysql://localhost:3306
+            ; url = jdbc:mysql://localhost:43316
             ; user = root
             ; password = df:dfprop/system-password.txt|
         }

--- a/dbflute_trohamadb/playsql/replace-schema-00-system.sql
+++ b/dbflute_trohamadb/playsql/replace-schema-00-system.sql
@@ -6,14 +6,14 @@ create database /*$dfprop.mainCatalog*/;
 
 -- #df:reviveUser()#
 -- #df:checkUser(mainUser)#
-create user /*$dfprop.mainUser*/@localhost identified by '/*$dfprop.mainPassword*/';
+create user /*$dfprop.mainUser*/@'%' identified by '/*$dfprop.mainPassword*/';
 
 -- #df:reviveUser()#
 -- #df:checkUser(grant)#
-grant all privileges on /*$dfprop.mainCatalog*/.* to /*$dfprop.mainUser*/@localhost;
+grant all privileges on /*$dfprop.mainCatalog*/.* to /*$dfprop.mainUser*/@'%';
 
 -- #df:reviveUser()#
 -- #df:checkUser(grant)#
-grant all privileges on /*$nextCatalog*/.* to /*$dfprop.mainUser*/@localhost;
+grant all privileges on /*$nextCatalog*/.* to /*$dfprop.mainUser*/@'%';
 
 flush privileges;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+# Copy from https://github.com/dbflute-test/dbflute-test-dbms-mysql/blob/master/docker-compose.yml by cabos (2022/07/03)
+version: "3.3"
+services:
+  db:
+    image: mysql:8.0.22
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+      MYSQL_ROOT_PASSWORD: ''
+    volumes:
+      - ./localdb/my-docker.cnf:/etc/my.cnf:delegated
+      - db_volume:/var/lib/mysql:delegated
+    ports:
+      - "43316:3306"
+volumes:
+  db_volume:

--- a/localdb/my-docker.cnf
+++ b/localdb/my-docker.cnf
@@ -1,0 +1,160 @@
+# Example MySQL config file for medium systems.
+#
+# This is for a system with little memory (32M - 64M) where MySQL plays
+# an important part, or systems up to 128M where MySQL is used together with
+# other programs (such as a web server)
+#
+# MySQL programs look for option files in a set of
+# locations which depend on the deployment platform.
+# You can copy this option file to one of those
+# locations. For information about these locations, see:
+# http://dev.mysql.com/doc/mysql/en/option-files.html
+#
+# In this file, you can use all long options that a program supports.
+# If you want to know which options a program supports, run the program
+# with the "--help" option.
+
+# The following options will be passed to all MySQL clients
+[client]
+#password	= your_password
+port		= 43316
+socket		= /tmp/dbflute-mysql-3306.sock
+
+# Here follows entries for some specific programs
+
+# The MySQL server
+[mysqld]
+basedir = ./mysql
+datadir = ./mysql/data
+port	= 3306
+socket	= /tmp/dbflute-mysql-3306.sock
+
+# /* * * * * * * * * * * * * * * * * * * * * * * * Custom Settings
+character-set-server=utf8mb4
+
+# to ignore case in SQL everywhere
+lower_case_table_names=1
+
+# to be strict but already set as default from 5.7 so unneeded
+#sql_mode="ONLY_FULL_GROUP_BY,TRADITIONAL"
+# * * * * * * * * * */
+
+# to suppress too many bin files
+expire_logs_days=3
+
+skip-external-locking
+key_buffer_size = 16M
+max_allowed_packet = 1M
+table_open_cache = 64
+sort_buffer_size = 512K
+net_buffer_length = 8K
+read_buffer_size = 256K
+read_rnd_buffer_size = 512K
+myisam_sort_buffer_size = 8M
+
+# Don't listen on a TCP/IP port at all. This can be a security enhancement,
+# if all processes that need to connect to mysqld run on the same host.
+# All interaction with mysqld must be made via Unix sockets or named pipes.
+# Note that using this option without enabling named pipes on Windows
+# (via the "enable-named-pipe" option) will render mysqld useless!
+#
+#skip-networking
+
+# Replication Master Server (default)
+# binary logging is required for replication
+log-bin=mysql-bin
+
+# binary logging format - mixed recommended
+binlog_format=mixed
+
+# required unique id between 1 and 2^32 - 1
+# defaults to 1 if master-host is not set
+# but will not function as a master if omitted
+server-id	= 1
+
+# Replication Slave (comment out master section to use this)
+#
+# To configure this host as a replication slave, you can choose between
+# two methods :
+#
+# 1) Use the CHANGE MASTER TO command (fully described in our manual) -
+#    the syntax is:
+#
+#    CHANGE MASTER TO MASTER_HOST=<host>, MASTER_PORT=<port>,
+#    MASTER_USER=<user>, MASTER_PASSWORD=<password> ;
+#
+#    where you replace <host>, <user>, <password> by quoted strings and
+#    <port> by the master's port number (3306 by default).
+#
+#    Example:
+#
+#    CHANGE MASTER TO MASTER_HOST='125.564.12.1', MASTER_PORT=3306,
+#    MASTER_USER='joe', MASTER_PASSWORD='secret';
+#
+# OR
+#
+# 2) Set the variables below. However, in case you choose this method, then
+#    start replication for the first time (even unsuccessfully, for example
+#    if you mistyped the password in master-password and the slave fails to
+#    connect), the slave will create a master.info file, and any later
+#    change in this file to the variables' values below will be ignored and
+#    overridden by the content of the master.info file, unless you shutdown
+#    the slave server, delete master.info and restart the slaver server.
+#    For that reason, you may want to leave the lines below untouched
+#    (commented) and instead use CHANGE MASTER TO (see above)
+#
+# required unique id between 2 and 2^32 - 1
+# (and different from the master)
+# defaults to 2 if master-host is set
+# but will not function as a slave if omitted
+#server-id       = 2
+#
+# The replication master for this slave - required
+#master-host     =   <hostname>
+#
+# The username the slave will use for authentication when connecting
+# to the master - required
+#master-user     =   <username>
+#
+# The password the slave will authenticate with when connecting to
+# the master - required
+#master-password =   <password>
+#
+# The port the master is listening on.
+# optional - defaults to 3306
+#master-port     =  <port>
+#
+# binary logging - not required for slaves, but recommended
+#log-bin=mysql-bin
+
+# Uncomment the following if you are using InnoDB tables
+#innodb_data_home_dir = /usr/local/mysql/data
+#innodb_data_file_path = ibdata1:10M:autoextend
+#innodb_log_group_home_dir = /usr/local/mysql/data
+# You can set .._buffer_pool_size up to 50 - 80 %
+# of RAM but beware of setting memory usage too high
+#innodb_buffer_pool_size = 16M
+#innodb_additional_mem_pool_size = 2M
+# Set .._log_file_size to 25 % of buffer pool size
+#innodb_log_file_size = 5M
+#innodb_log_buffer_size = 8M
+#innodb_flush_log_at_trx_commit = 1
+#innodb_lock_wait_timeout = 50
+
+[mysqldump]
+quick
+max_allowed_packet = 16M
+
+[mysql]
+no-auto-rehash
+# Remove the next comment character if you are not familiar with SQL
+#safe-updates
+
+[myisamchk]
+key_buffer_size = 20M
+sort_buffer_size = 20M
+read_buffer = 2M
+write_buffer = 2M
+
+[mysqlhotcopy]
+interactive-timeout


### PR DESCRIPTION
7/17までに一時レビューをいただけるとうれしいです

## やったこと
intro メンバーが同じ環境の mysql を利用できるように

- `docker-compose up` でコンテナが立ち上がるように docker-compose.yml 及び周辺の設定ファイルを追加
- dfprop 上の trohamadb の接続先ポート番号を 3306 -> 43316 に変更
- docker を利用するにあたって、mysqlユーザのhost情報を変更
- コンテナの立ち上げ方をドキュメントに記載

## 参考にしたもの
一部コードのコピーなども行っています
https://github.com/dbflute-test/dbflute-test-dbms-mysql

## 動作確認
- [ ] `docker-compose up -d` でmysql8.0のコンテナが立ち上がること
- [ ] テスト用に立ち上げた intro 上から
   - replace schema が成功すること
   - document task が成功すること 