### PR TITLE
#458 generate DBFlute classes for 1.2.6 (to synchronize with runtime)

### DIFF
--- a/src/main/java/org/dbflute/intro/dbflute/allcommon/DBCurrent.java
+++ b/src/main/java/org/dbflute/intro/dbflute/allcommon/DBCurrent.java
@@ -42,17 +42,14 @@ public class DBCurrent {
 
     protected DBDef _currentDBDef;
     {
-        _currentDBDef = DBDef.codeOf("h2");
-        if (_currentDBDef == null) {
-            _currentDBDef = DBDef.Unknown;
-        }
+        _currentDBDef = DBDef.of("h2").orElse(DBDef.Unknown);
     }
 
     // ===================================================================================
     //                                                                         Constructor
     //                                                                         ===========
     /**
-     * Constructor.
+     * Only for singleton.
      */
     private DBCurrent() {
     }
@@ -61,8 +58,8 @@ public class DBCurrent {
     //                                                                           Singleton
     //                                                                           =========
     /**
-     * Get singleton instance.
-     * @return Singleton instance. (NotNull)
+     * Get the saved singleton instance.
+     * @return always same instance. (NotNull)
      */
     public static DBCurrent getInstance() {
         return _instance;

--- a/src/main/java/org/dbflute/intro/dbflute/bsbhv/BsClsTargetContainerBhv.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsbhv/BsClsTargetContainerBhv.java
@@ -45,25 +45,25 @@ import org.dbflute.intro.dbflute.cbean.*;
  *     CONTAINER_CODE, CONTAINER_NAME, DISPLAY_ORDER
  *
  * [sequence]
- *
+ *     
  *
  * [identity]
- *
+ *     
  *
  * [version-no]
- *
+ *     
  *
  * [foreign table]
- *
+ *     
  *
  * [referrer table]
- *
+ *     
  *
  * [foreign property]
- *
+ *     
  *
  * [referrer property]
- *
+ *     
  * </pre>
  * @author DBFlute(AutoGenerator)
  */

--- a/src/main/java/org/dbflute/intro/dbflute/bsbhv/BsClsTargetDatabaseBhv.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsbhv/BsClsTargetDatabaseBhv.java
@@ -45,25 +45,25 @@ import org.dbflute.intro.dbflute.cbean.*;
  *     DATABASE_CODE, DATABASE_NAME, JDBC_DRIVER_FQCN, URL_TEMPLATE, DEFAULT_SCHEMA, SCHEMA_REQUIRED_FLG, SCHEMA_UPPER_CASE_FLG, USER_INPUT_ASSIST_FLG, EMBEDDED_JAR_FLG, DISPLAY_ORDER
  *
  * [sequence]
- *
+ *     
  *
  * [identity]
- *
+ *     
  *
  * [version-no]
- *
+ *     
  *
  * [foreign table]
- *
+ *     
  *
  * [referrer table]
- *
+ *     
  *
  * [foreign property]
- *
+ *     
  *
  * [referrer property]
- *
+ *     
  * </pre>
  * @author DBFlute(AutoGenerator)
  */

--- a/src/main/java/org/dbflute/intro/dbflute/bsbhv/BsClsTargetLanguageBhv.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsbhv/BsClsTargetLanguageBhv.java
@@ -45,25 +45,25 @@ import org.dbflute.intro.dbflute.cbean.*;
  *     LANGUAGE_CODE, LANGUAGE_NAME, DISPLAY_ORDER
  *
  * [sequence]
- *
+ *     
  *
  * [identity]
- *
+ *     
  *
  * [version-no]
- *
+ *     
  *
  * [foreign table]
- *
+ *     
  *
  * [referrer table]
- *
+ *     
  *
  * [foreign property]
- *
+ *     
  *
  * [referrer property]
- *
+ *     
  * </pre>
  * @author DBFlute(AutoGenerator)
  */

--- a/src/main/java/org/dbflute/intro/dbflute/bsbhv/loader/LoaderOfClsTargetContainer.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsbhv/loader/LoaderOfClsTargetContainer.java
@@ -31,25 +31,25 @@ import org.dbflute.intro.dbflute.exentity.*;
  *     CONTAINER_CODE, CONTAINER_NAME, DISPLAY_ORDER
  *
  * [sequence]
- *
+ *     
  *
  * [identity]
- *
+ *     
  *
  * [version-no]
- *
+ *     
  *
  * [foreign table]
- *
+ *     
  *
  * [referrer table]
- *
+ *     
  *
  * [foreign property]
- *
+ *     
  *
  * [referrer property]
- *
+ *     
  * </pre>
  * @author DBFlute(AutoGenerator)
  */

--- a/src/main/java/org/dbflute/intro/dbflute/bsbhv/loader/LoaderOfClsTargetDatabase.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsbhv/loader/LoaderOfClsTargetDatabase.java
@@ -31,25 +31,25 @@ import org.dbflute.intro.dbflute.exentity.*;
  *     DATABASE_CODE, DATABASE_NAME, JDBC_DRIVER_FQCN, URL_TEMPLATE, DEFAULT_SCHEMA, SCHEMA_REQUIRED_FLG, SCHEMA_UPPER_CASE_FLG, USER_INPUT_ASSIST_FLG, EMBEDDED_JAR_FLG, DISPLAY_ORDER
  *
  * [sequence]
- *
+ *     
  *
  * [identity]
- *
+ *     
  *
  * [version-no]
- *
+ *     
  *
  * [foreign table]
- *
+ *     
  *
  * [referrer table]
- *
+ *     
  *
  * [foreign property]
- *
+ *     
  *
  * [referrer property]
- *
+ *     
  * </pre>
  * @author DBFlute(AutoGenerator)
  */

--- a/src/main/java/org/dbflute/intro/dbflute/bsbhv/loader/LoaderOfClsTargetLanguage.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsbhv/loader/LoaderOfClsTargetLanguage.java
@@ -31,25 +31,25 @@ import org.dbflute.intro.dbflute.exentity.*;
  *     LANGUAGE_CODE, LANGUAGE_NAME, DISPLAY_ORDER
  *
  * [sequence]
- *
+ *     
  *
  * [identity]
- *
+ *     
  *
  * [version-no]
- *
+ *     
  *
  * [foreign table]
- *
+ *     
  *
  * [referrer table]
- *
+ *     
  *
  * [foreign property]
- *
+ *     
  *
  * [referrer property]
- *
+ *     
  * </pre>
  * @author DBFlute(AutoGenerator)
  */

--- a/src/main/java/org/dbflute/intro/dbflute/bsentity/BsClsTargetContainer.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsentity/BsClsTargetContainer.java
@@ -35,25 +35,25 @@ import org.dbflute.intro.dbflute.exentity.*;
  *     CONTAINER_CODE, CONTAINER_NAME, DISPLAY_ORDER
  *
  * [sequence]
- *
+ *     
  *
  * [identity]
- *
+ *     
  *
  * [version-no]
- *
+ *     
  *
  * [foreign table]
- *
+ *     
  *
  * [referrer table]
- *
+ *     
  *
  * [foreign property]
- *
+ *     
  *
  * [referrer property]
- *
+ *     
  *
  * [get/set template]
  * /= = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
@@ -120,7 +120,7 @@ public abstract class BsClsTargetContainer extends AbstractEntity implements Dom
      * @return The instance of classification definition (as ENUM type). (NullAllowed: when the column value is null)
      */
     public CDef.TargetContainer getContainerCodeAsTargetContainer() {
-        return CDef.TargetContainer.codeOf(getContainerCode());
+        return CDef.TargetContainer.of(getContainerCode()).orElse(null);
     }
 
     /**

--- a/src/main/java/org/dbflute/intro/dbflute/bsentity/BsClsTargetDatabase.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsentity/BsClsTargetDatabase.java
@@ -35,25 +35,25 @@ import org.dbflute.intro.dbflute.exentity.*;
  *     DATABASE_CODE, DATABASE_NAME, JDBC_DRIVER_FQCN, URL_TEMPLATE, DEFAULT_SCHEMA, SCHEMA_REQUIRED_FLG, SCHEMA_UPPER_CASE_FLG, USER_INPUT_ASSIST_FLG, EMBEDDED_JAR_FLG, DISPLAY_ORDER
  *
  * [sequence]
- *
+ *     
  *
  * [identity]
- *
+ *     
  *
  * [version-no]
- *
+ *     
  *
  * [foreign table]
- *
+ *     
  *
  * [referrer table]
- *
+ *     
  *
  * [foreign property]
- *
+ *     
  *
  * [referrer property]
- *
+ *     
  *
  * [get/set template]
  * /= = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
@@ -155,7 +155,7 @@ public abstract class BsClsTargetDatabase extends AbstractEntity implements Doma
      * @return The instance of classification definition (as ENUM type). (NullAllowed: when the column value is null)
      */
     public CDef.TargetDatabase getDatabaseCodeAsTargetDatabase() {
-        return CDef.TargetDatabase.codeOf(getDatabaseCode());
+        return CDef.TargetDatabase.of(getDatabaseCode()).orElse(null);
     }
 
     /**
@@ -176,7 +176,7 @@ public abstract class BsClsTargetDatabase extends AbstractEntity implements Doma
      * @return The instance of classification definition (as ENUM type). (NullAllowed: when the column value is null)
      */
     public CDef.Flg getSchemaRequiredFlgAsFlg() {
-        return CDef.Flg.codeOf(getSchemaRequiredFlg());
+        return CDef.Flg.of(getSchemaRequiredFlg()).orElse(null);
     }
 
     /**
@@ -196,7 +196,7 @@ public abstract class BsClsTargetDatabase extends AbstractEntity implements Doma
      * @param determination The determination, true or false. (NullAllowed: if null, null value is set to the column)
      */
     public void setSchemaRequiredFlgAsBoolean(Boolean determination) {
-        setSchemaRequiredFlgAsFlg(CDef.Flg.codeOf(determination));
+        setSchemaRequiredFlgAsFlg(CDef.Flg.of(determination).orElse(null));
     }
 
     /**
@@ -207,7 +207,7 @@ public abstract class BsClsTargetDatabase extends AbstractEntity implements Doma
      * @return The instance of classification definition (as ENUM type). (NullAllowed: when the column value is null)
      */
     public CDef.Flg getSchemaUpperCaseFlgAsFlg() {
-        return CDef.Flg.codeOf(getSchemaUpperCaseFlg());
+        return CDef.Flg.of(getSchemaUpperCaseFlg()).orElse(null);
     }
 
     /**
@@ -227,7 +227,7 @@ public abstract class BsClsTargetDatabase extends AbstractEntity implements Doma
      * @param determination The determination, true or false. (NullAllowed: if null, null value is set to the column)
      */
     public void setSchemaUpperCaseFlgAsBoolean(Boolean determination) {
-        setSchemaUpperCaseFlgAsFlg(CDef.Flg.codeOf(determination));
+        setSchemaUpperCaseFlgAsFlg(CDef.Flg.of(determination).orElse(null));
     }
 
     /**
@@ -238,7 +238,7 @@ public abstract class BsClsTargetDatabase extends AbstractEntity implements Doma
      * @return The instance of classification definition (as ENUM type). (NullAllowed: when the column value is null)
      */
     public CDef.Flg getUserInputAssistFlgAsFlg() {
-        return CDef.Flg.codeOf(getUserInputAssistFlg());
+        return CDef.Flg.of(getUserInputAssistFlg()).orElse(null);
     }
 
     /**
@@ -258,7 +258,7 @@ public abstract class BsClsTargetDatabase extends AbstractEntity implements Doma
      * @param determination The determination, true or false. (NullAllowed: if null, null value is set to the column)
      */
     public void setUserInputAssistFlgAsBoolean(Boolean determination) {
-        setUserInputAssistFlgAsFlg(CDef.Flg.codeOf(determination));
+        setUserInputAssistFlgAsFlg(CDef.Flg.of(determination).orElse(null));
     }
 
     /**
@@ -269,7 +269,7 @@ public abstract class BsClsTargetDatabase extends AbstractEntity implements Doma
      * @return The instance of classification definition (as ENUM type). (NullAllowed: when the column value is null)
      */
     public CDef.Flg getEmbeddedJarFlgAsFlg() {
-        return CDef.Flg.codeOf(getEmbeddedJarFlg());
+        return CDef.Flg.of(getEmbeddedJarFlg()).orElse(null);
     }
 
     /**
@@ -289,7 +289,7 @@ public abstract class BsClsTargetDatabase extends AbstractEntity implements Doma
      * @param determination The determination, true or false. (NullAllowed: if null, null value is set to the column)
      */
     public void setEmbeddedJarFlgAsBoolean(Boolean determination) {
-        setEmbeddedJarFlgAsFlg(CDef.Flg.codeOf(determination));
+        setEmbeddedJarFlgAsFlg(CDef.Flg.of(determination).orElse(null));
     }
 
     // ===================================================================================

--- a/src/main/java/org/dbflute/intro/dbflute/bsentity/BsClsTargetLanguage.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsentity/BsClsTargetLanguage.java
@@ -35,25 +35,25 @@ import org.dbflute.intro.dbflute.exentity.*;
  *     LANGUAGE_CODE, LANGUAGE_NAME, DISPLAY_ORDER
  *
  * [sequence]
- *
+ *     
  *
  * [identity]
- *
+ *     
  *
  * [version-no]
- *
+ *     
  *
  * [foreign table]
- *
+ *     
  *
  * [referrer table]
- *
+ *     
  *
  * [foreign property]
- *
+ *     
  *
  * [referrer property]
- *
+ *     
  *
  * [get/set template]
  * /= = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
@@ -120,7 +120,7 @@ public abstract class BsClsTargetLanguage extends AbstractEntity implements Doma
      * @return The instance of classification definition (as ENUM type). (NullAllowed: when the column value is null)
      */
     public CDef.TargetLanguage getLanguageCodeAsTargetLanguage() {
-        return CDef.TargetLanguage.codeOf(getLanguageCode());
+        return CDef.TargetLanguage.of(getLanguageCode()).orElse(null);
     }
 
     /**

--- a/src/main/java/org/dbflute/intro/dbflute/cbean/cq/bs/AbstractBsClsTargetDatabaseCQ.java
+++ b/src/main/java/org/dbflute/intro/dbflute/cbean/cq/bs/AbstractBsClsTargetDatabaseCQ.java
@@ -678,7 +678,7 @@ public abstract class AbstractBsClsTargetDatabaseCQ extends AbstractConditionQue
      * @param determination The determination, true or false. (basically NotNull: error as default, or no condition as option)
      */
     public void setSchemaRequiredFlg_Equal_AsBoolean(Boolean determination) {
-        setSchemaRequiredFlg_Equal_AsFlg(CDef.Flg.codeOf(determination));
+        setSchemaRequiredFlg_Equal_AsFlg(CDef.Flg.of(determination).get());
     }
 
     /**
@@ -815,7 +815,7 @@ public abstract class AbstractBsClsTargetDatabaseCQ extends AbstractConditionQue
      * @param determination The determination, true or false. (basically NotNull: error as default, or no condition as option)
      */
     public void setSchemaUpperCaseFlg_Equal_AsBoolean(Boolean determination) {
-        setSchemaUpperCaseFlg_Equal_AsFlg(CDef.Flg.codeOf(determination));
+        setSchemaUpperCaseFlg_Equal_AsFlg(CDef.Flg.of(determination).get());
     }
 
     /**
@@ -952,7 +952,7 @@ public abstract class AbstractBsClsTargetDatabaseCQ extends AbstractConditionQue
      * @param determination The determination, true or false. (basically NotNull: error as default, or no condition as option)
      */
     public void setUserInputAssistFlg_Equal_AsBoolean(Boolean determination) {
-        setUserInputAssistFlg_Equal_AsFlg(CDef.Flg.codeOf(determination));
+        setUserInputAssistFlg_Equal_AsFlg(CDef.Flg.of(determination).get());
     }
 
     /**
@@ -1089,7 +1089,7 @@ public abstract class AbstractBsClsTargetDatabaseCQ extends AbstractConditionQue
      * @param determination The determination, true or false. (basically NotNull: error as default, or no condition as option)
      */
     public void setEmbeddedJarFlg_Equal_AsBoolean(Boolean determination) {
-        setEmbeddedJarFlg_Equal_AsFlg(CDef.Flg.codeOf(determination));
+        setEmbeddedJarFlg_Equal_AsFlg(CDef.Flg.of(determination).get());
     }
 
     /**


### PR DESCRIPTION
以前DBFluteを1.2.6にアップしたときに、introdbの自動生成処理がされてなかったようで、
自動生成コードとDBFlute Runtimeのすれ違いが起きていました。
(非推奨のメソッドを呼び出していて、IDE上で警告になってしまっている)

manage の renewal (1) を実行しただけです。
自動生成クラス内のJavaDocコメントとかもある程度修正されています。

動作確認もしたので、パット見で問題無さそうであればApproveをお願いします。

レビュー期限は1月12日(木)です。
→ 1/19(木)に変更
