### PR TITLE
Riot7対応 Feature/#486 riot7 returntype nullunion, いったん使ってもらうためのプルリク

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -6,32 +6,19 @@
     "es2021": true,
     "jest/globals": true
   },
-  "extends": [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
-    "prettier"
-  ],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"],
   "parserOptions": {
     "sourceType": "module"
   },
   "rules": {
     "no-console": "error",
-    "linebreak-style": [
-      "error",
-      "unix"
-    ],
+    "linebreak-style": ["error", "unix"],
     "no-var": "error",
     "prefer-arrow-callback": "error"
   },
-  "plugins": [
-    "html",
-    "jest"
-  ],
+  "plugins": ["html", "jest"],
   "settings": {
-    "html/html-extensions": [
-      ".html",
-      ".riot"
-    ]
+    "html/html-extensions": [".html", ".riot"]
   },
   "globals": {
     "opts": true,

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -14,7 +14,8 @@
     "no-console": "error",
     "linebreak-style": ["error", "unix"],
     "no-var": "error",
-    "prefer-arrow-callback": "error"
+    "prefer-arrow-callback": "error",
+    "@typescript-eslint/explicit-function-return-type": "error"
   },
   "plugins": ["html", "jest"],
   "settings": {

--- a/frontend/src/static/app/app-events.ts
+++ b/frontend/src/static/app/app-events.ts
@@ -37,7 +37,7 @@ type ShowResultContent = {
  * 結果ビュー表示イベントを購読する。
  * @param {(content: ShowResultContent) => void} callback 結果ビューに表示するデータを受け取るコールバック (NotNull)
  */
-export function subscribeShowResult(callback: (content: ShowResultContent) => void) {
+export function subscribeShowResult(callback: (content: ShowResultContent) => void): void {
   appObservable.on('show-result', (content: ShowResultContent) => callback(content))
 }
 
@@ -45,6 +45,6 @@ export function subscribeShowResult(callback: (content: ShowResultContent) => vo
  * 結果ビュー表示イベントを発行する。
  * @param {ShowResultContent} content 結果ビューの表示情報 (NotNull)
  */
-export function triggerShowResult(content: ShowResultContent) {
+export function triggerShowResult(content: ShowResultContent): void {
   appObservable.trigger('show-result', content)
 }

--- a/frontend/src/static/app/app-plugin.ts
+++ b/frontend/src/static/app/app-plugin.ts
@@ -12,8 +12,8 @@ export interface DBFluteIntroPlugin {
   /**
    * Componentにclass名を動的に与えるためのオブジェクトを構築する
    * 具体例は [riotのマイグレーションガイド]{@link https://riot.js.org/ja/migration-guide/#%E3%83%86%E3%83%B3%E3%83%97%E3%83%AC%E3%83%BC%E3%83%88%E3%81%AE%E3%82%B7%E3%83%A7%E3%83%BC%E3%83%88%E3%82%AB%E3%83%83%E3%83%88}を参照
-   * @param classes - class list as object
-   * @returns return only the classes having a truthy value
+   * @param classes - class list as object (NotNull)
+   * @returns return only the classes having a truthy value (NotNull)
    */
   classNames: (classes: { [key: string]: boolean }) => string
 
@@ -30,21 +30,21 @@ export interface DBFluteIntroPlugin {
    * 指定されたselectorでHTMLのDOM要素を探す。(ないかもしれないときに使う)
    * - $関数で取得したElementに型を付与する際のヘルパー関数
    * - 複数のplugin関数で再利用するためglobalな関数として定義
-   * @param selector $関数に入れるselector文字列 e.g. [ref=jdbcDriverFqcn]
+   * @param selector $関数に入れるselector文字列 e.g. [ref=jdbcDriverFqcn] (NotNull)
    * @returns 対象のタグのHTMLオブジェクト (NullAllowed: if not found)
    */
-  elementAs: <HTMLElement extends Element>(selector: string) => HTMLElement | null
+  elementAs: <EL extends HTMLElement>(selector: string) => EL | null
 
   /**
    * 指定されたselectorでinputのDOM要素を探す。(ないかもしれないときに使う)
-   * @param selector $関数に入れるselector文字列 e.g. [ref=jdbcDriverFqcn]
+   * @param selector $関数に入れるselector文字列 e.g. [ref=jdbcDriverFqcn] (NotNull)
    * @returns 対象のタグのHTMLオブジェクト (NullAllowed: if not found)
    */
   inputElementBy: (selector: string) => HTMLInputElement | null
 
   /**
    * 指定されたselectorでinputのDOM要素を探す。(存在するはずのときに使う)
-   * @param selector $関数に入れるselector文字列 e.g. [ref=jdbcDriverFqcn]
+   * @param selector $関数に入れるselector文字列 e.g. [ref=jdbcDriverFqcn] (NotNull)
    * @returns 対象のタグのHTMLオブジェクト (NotNull: exception if not found)
    * @throws {ElementNotFoundError} 指定されたselectorに合致するinputのelementが存在しなかったら
    */
@@ -65,6 +65,14 @@ export interface DBFluteIntroPlugin {
 export class ElementNotFoundError extends Error {
   constructor(msg: string) {
     super(msg)
+
+    // #thinking ChatGPTに言われて、タイトル的なnameを入れてみた jflute (2023/12/25)
+    this.name = '指定されたselectorに対応する要素がないぞ例外'
+
+    // #thinking こうするとスタックトレースを保持される？的なことをChatGPTに言われて書いてみたが、いったん無しで試してみよう jflute (2023/12/25)
+    //if (Error.captureStackTrace) {
+    //  Error.captureStackTrace(this, ElementNotFoundError)
+    //}
   }
 }
 
@@ -98,8 +106,7 @@ const dbflutePlugin: DBFluteIntroPlugin = {
     })
   },
 
-  // #thinking jflute 実装インスタンスだけ T になってるのは、Javaで言う共変戻り値的な感じ？ (2023/09/25)
-  elementAs<T extends Element>(selector: string): T | null {
+  elementAs<EL extends HTMLElement>(selector: string): EL | null {
     return elementAs.bind(this, selector).apply() // 戻り型推論ちゃんと効いてるっぽい
   },
 
@@ -121,8 +128,9 @@ const dbflutePlugin: DBFluteIntroPlugin = {
 //                                          Element Handling
 //                                          ----------------
 // dbflutePluginの中で共通的に利用される関数をプライベート関数的に扱うために外に出している
-function elementAs<T extends Element>(selector: string): T {
-  return this.$(selector) as T
+function elementAs<EL extends HTMLElement>(selector: string): EL | null {
+  // #thinking jflute $()の戻りってHTMLElementじゃなくてElementだと思うんだけど、ノーチェックでいいのかな？ (2023/12/25)
+  return this.$(selector) as EL
 }
 
 // =======================================================================================

--- a/frontend/src/static/app/app-plugin.ts
+++ b/frontend/src/static/app/app-plugin.ts
@@ -144,7 +144,7 @@ function elementAs<EL extends HTMLElement>(selector: string): EL | null {
  * 任意のComponentから直接呼び出せる。
  * @param component Riotコンポーネント自身、ここにプロパティを追加したりする (NotNull)
  */
-export default function plugin(component: RiotComponent) {
+export default function plugin(component: RiotComponent): RiotComponent {
   // 定義されている関数(厳密にはプロパティ)のMapを用意
   const propertyDescriptors = Object.getOwnPropertyDescriptors(dbflutePlugin)
 

--- a/frontend/src/static/app/app-route.ts
+++ b/frontend/src/static/app/app-route.ts
@@ -53,7 +53,7 @@ export function createRouting(definition: RoutesDefinition): Routes {
  * ルーティング関連のcleanup処理
  * - 監視しているstreamの破棄を行う
  */
-export function endRouting() {
+export function endRouting(): void {
   Object.values(appRoutes).forEach((route) => {
     routeStreams.get(route.path)?.end()
   })

--- a/frontend/src/static/app/app-route.ts
+++ b/frontend/src/static/app/app-route.ts
@@ -70,7 +70,8 @@ const routeStreams = new Map()
  * 指定されたパスのstreamを取得する
  * - なければ作成し、キャッシュする
  */
-function ensureRouteStream(path: string) {
+function ensureRouteStream(path: string): any {
+  // #thinking jflute Riot側でJSのみのコードで型が指定できない(!?)ので苦肉のany (2024/01/07)
   if (!routeStreams.get(path)) {
     routeStreams.set(path, riotRoute(path, {}))
   }

--- a/frontend/src/static/app/pages/welcome/welcome.ts
+++ b/frontend/src/static/app/pages/welcome/welcome.ts
@@ -175,23 +175,25 @@ export default withIntroTypes<Welcome>({
    */
   onclickCreate() {
     const body: WelcomeCreateBody = {
+      // #thinking inputElement用意してるくらいなら、リストボックスもthis.$()の部分使わなくていいようにしてもいい？ jflute (2023/12/25)
+      // (というか、そもそもHTMLElementとして取得したらダメなのか？)
       client: {
-        projectName: this.inputElementBy('[ref=projectName]').value,
+        projectName: this.inputElementByRequired('[ref=projectName]').value,
         databaseCode: this.$('[ref=databaseCode]').getAttribute('value'),
         mainSchemaSettings: {
-          user: this.inputElementBy('[ref=user]').value,
-          url: this.inputElementBy('[ref=url]').value,
-          schema: this.inputElementBy('[ref=schema]').value,
-          password: this.inputElementBy('[ref=password]').value,
+          user: this.inputElementByRequired('[ref=user]').value,
+          url: this.inputElementByRequired('[ref=url]').value,
+          schema: this.inputElementByRequired('[ref=schema]').value,
+          password: this.inputElementByRequired('[ref=password]').value,
         },
         dbfluteVersion: this.latestVersion,
-        packageBase: this.inputElementBy('[ref=packageBase]').value,
+        packageBase: this.inputElementByRequired('[ref=packageBase]').value,
         containerCode: this.$('[ref=containerCode]').getAttribute('value'),
         languageCode: this.$('[ref=languageCode]').getAttribute('value'),
         jdbcDriver: this.state.jdbcDriver,
-        jdbcDriverFqcn: this.inputElementBy('[ref=jdbcDriverFqcn]').value,
+        jdbcDriverFqcn: this.inputElementByRequired('[ref=jdbcDriverFqcn]').value,
       },
-      testConnection: this.inputElementBy('[ref=testConnection]').checked,
+      testConnection: this.inputElementByRequired('[ref=testConnection]').checked,
     }
     this.suLoading(true)
     api


### PR DESCRIPTION
inputElementByRequired()が使えるようになってます
```
projectName: this.inputElementByRequired('[ref=projectName]').value,
```

関数の戻り値を明示的に入れないとエラーになるeslint設定を入れました。
```
@typescript-eslint/explicit-function-return-type
```

welcome.tsは対応していますので参考にしてください。