### PR TITLE
Feature/#493 handle empty object

### DIFF
--- a/frontend/src/static/app/api/api.ts
+++ b/frontend/src/static/app/api/api.ts
@@ -315,8 +315,13 @@ class Api {
     })
   }
 
-  latestResult(projectName: string, task: string): Promise<LogBean> {
-    return apiClient.get(`api/log/latest/${projectName}/${task}`)
+  latestResult(projectName: string, task: string): Promise<LogBean | null> {
+    return apiClient.get(`api/log/latest/${projectName}/${task}`).then((body) => {
+      // TODO cabos レスポンスの形式が変わる実装になっているので、変わらないように修正する (2023-01-07 at Roppongi)
+      // https://github.com/dbflute/dbflute-intro/issues/493
+      if (Object.keys(body).length === 0) return null
+      return body
+    })
   }
 
   // ===============================================================================

--- a/frontend/src/static/app/pages/client/alter-check/alter-check.ts
+++ b/frontend/src/static/app/pages/client/alter-check/alter-check.ts
@@ -246,12 +246,11 @@ export default withIntroTypes<AlterCheck>({
    * @return {Promise<AlterLatestResultState>} 最新の実行失敗結果.最新が成功している場合はnull (Nullable)
    */
   async prepareLatestFailureResult(ngMarkFile: AlterSQLResultNgMarkFilePart | undefined): Promise<AlterLatestResultState | undefined> {
-    return api.latestResult(this.props.projectName, 'alterCheck').then((res) => {
-      const success = res.fileName.includes('success')
-      if (success) {
+    return api.latestResult(this.props.projectName, 'alterCheck').then((body) => {
+      if (!body || body.fileName.includes('success')) {
         return
       }
-      const content = res.content
+      const content = body.content
       if (!ngMarkFile) {
         return {
           title: 'Result: Failure',

--- a/src/main/java/org/dbflute/intro/app/web/log/LogAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/log/LogAction.java
@@ -75,6 +75,8 @@ public class LogAction extends IntroBaseAction {
         return logPhysicalLogic.findLatestResultFile(clientName, task).map((file) -> {
             return asJson(new LogBean(file.getName(), cutOffErrorLogIfNeeds(flutyFileLogic.readFile(file))));
         }).orElseGet(() -> {
+            // TODO cabos レスポンスの形式が変わる実装になっているので、変わらないように修正する (2023-01-07 at Roppongi)
+            // https://github.com/dbflute/dbflute-intro/issues/493
             return JsonResponse.asEmptyBody();
         });
     }


### PR DESCRIPTION
- `api/log/latest/${projectName}/${task}` で `{}` が返ってくることを考慮した実装に変更
- 上記修正で影響を受ける箇所の修正（alter-check.ts のみ）
- `res` -> `body` に統一
- 後の修正に向けてコメント