### PR TITLE
#490 feat: グローバルなエラーハンドリングを追加

### DIFF
--- a/frontend/src/static/app/app-events.ts
+++ b/frontend/src/static/app/app-events.ts
@@ -13,6 +13,7 @@ import observable from 'riot-observable'
 // (できるだけ、このモジュールファイル内で完結させて、公開関数だけ呼んでもらうがいいかな？)
 // → プルリク上でhakibaに確認をしたので、もうexportを削除しちゃった (2023/07/10)
 const appObservable = observable()
+const globalErrorObservable = observable()
 
 // ===================================================================================
 //                                                                         Show Result
@@ -24,10 +25,10 @@ const appObservable = observable()
  */
 type ShowResultContent = {
   /** モーダルのサイズ。指定できるサイズは <a href="https://semantic-ui-riot.web.app/module/modal#size">こちら</a> 参照 */
-  modalSize: string | undefined
+  modalSize?: string
 
   /** モーダルのヘッダーに表示するタイトル */
-  header: string | undefined
+  header?: string
 
   /** モーダルのに表示するメッセージ群 */
   messages: string[]
@@ -47,4 +48,18 @@ export function subscribeShowResult(callback: (content: ShowResultContent) => vo
  */
 export function triggerShowResult(content: ShowResultContent): void {
   appObservable.trigger('show-result', content)
+}
+
+/**
+ * グローバルエラーを購読します
+ */
+export function subscribeGlobalError(callback: (message: string) => void): void {
+  globalErrorObservable.on('handle-error', callback)
+}
+
+/**
+ * グローバルエラーを発行します
+ */
+export function triggerGlobalError(message: string): void {
+  globalErrorObservable.trigger('handle-error', message)
 }

--- a/frontend/src/static/app/app-events.ts
+++ b/frontend/src/static/app/app-events.ts
@@ -52,6 +52,7 @@ export function triggerShowResult(content: ShowResultContent): void {
 
 /**
  * グローバルエラーを購読します
+ * @param callback メッセージを処理するcallback (NotNull) e.g.モーダルを使ったメッセージの通知処理
  */
 export function subscribeGlobalError(callback: (message: string) => void): void {
   globalErrorObservable.on('handle-error', callback)
@@ -59,6 +60,7 @@ export function subscribeGlobalError(callback: (message: string) => void): void 
 
 /**
  * グローバルエラーを発行します
+ * @param message グローバルエラーとして通知するメッセージ (NotNull)
  */
 export function triggerGlobalError(message: string): void {
   globalErrorObservable.trigger('handle-error', message)

--- a/frontend/src/static/app/index.ts
+++ b/frontend/src/static/app/index.ts
@@ -26,6 +26,9 @@ import './shared/i18n'
 // アプリ独自のプラグイン関数をriotにinstall()するための関数
 import introPlugin from './app-plugin'
 
+// グローバルエラーを監視するための関数
+import { subscribeGlobalError, triggerGlobalError, triggerShowResult } from './app-events'
+
 // 全てのRiotコンポーネントにアプリ共通の関数を付与していく
 riot.install(introPlugin)
 
@@ -38,3 +41,17 @@ if (root) {
 } else {
   throw new Error('not found riot root element')
 }
+
+// フロントエンドのグローバルエラーの監視を開始
+subscribeGlobalError((msg) => {
+  // エラーを拾った際、ダイアログでエラーを表示する
+  triggerShowResult({ header: 'Unexpected Frontend Error', messages: [msg] })
+})
+// キャッチされなかったerrorを拾うためEventListenerを設定
+window.addEventListener('error', (event) => {
+  triggerGlobalError(event.error)
+})
+// Promiseの中でthrowされたエラーを拾うため、さらにunhandledrejectionにもEventListenerを設定
+window.addEventListener('unhandledrejection', (event) => {
+  triggerGlobalError(event.type)
+})


### PR DESCRIPTION
## やったこと

- キャッチされていないerrorを拾うためのイベントリスナーを追加
- エラー内容を表示するモーダルを追加

## テスト方法

- create.ts で `inputElementBy` で指定しているパラメータ名をでたらめなものにして、サブミットする
  - → エラー内容がモーダルで表示される