### PR TITLE
#535 javadoc から ul タグに囲われていない li タグを削除

### DIFF
--- a/src/main/java/org/dbflute/intro/app/logic/dfprop/DfpropReadLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/dfprop/DfpropReadLogic.java
@@ -162,8 +162,9 @@ public class DfpropReadLogic {
     }
 
     /**
-     * schema diagramのファイルを取得します
-     * <li>ファイルパスはDBFluteIntroプロジェクトからの相対パスに変換します</li>
+     * schema diagramのファイルを取得します<br>
+     * ファイルパスはDBFluteIntroプロジェクトからの相対パスに変換します
+     *
      * @param projectName The project name of DBFlute client. (NotNull)
      * @param diagramName The diagram name. (NotNull)
      * @return schema diagram file path (NotNull, EmptyAllowed: not setup schemaDiagramMap)


### PR DESCRIPTION
細かいことですが、CI 上で気になったので修正しました。

https://app.circleci.com/pipelines/github/dbflute/dbflute-intro/793/workflows/6c360d94-b9d5-4b26-9592-725a13f68ccf/jobs/1497