### PR TITLE
#535 javadoc から ul タグに囲われていない li タグを削除

### DIFF
--- a/src/main/java/org/dbflute/intro/app/logic/dfprop/DfpropReadLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/dfprop/DfpropReadLogic.java
@@ -162,8 +162,9 @@ public class DfpropReadLogic {
     }
 
     /**
-     * schema diagramのファイルを取得します
-     * <li>ファイルパスはDBFluteIntroプロジェクトからの相対パスに変換します</li>
+     * schema diagramのファイルを取得します<br>
+     * ファイルパスはDBFluteIntroプロジェクトからの相対パスに変換します
+     *
      * @param projectName The project name of DBFlute client. (NotNull)
      * @param diagramName The diagram name. (NotNull)
      * @return schema diagram file path (NotNull, EmptyAllowed: not setup schemaDiagramMap)


### PR DESCRIPTION
こちらと内容同じです。
https://github.com/dbflute/dbflute-intro/pull/536