### PR TITLE
#552 テンプレートファイルのライセンスヘッダを2026年に

### DIFF
--- a/LICENSE_HEADER
+++ b/LICENSE_HEADER
@@ -1,4 +1,4 @@
-Copyright 2014-2025 the original author or authors.
+Copyright 2014-2026 the original author or authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/dbflute_introdb/freegen/ControlFreeGen.vm
+++ b/dbflute_introdb/freegen/ControlFreeGen.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/doc/ControlDocument.vm
+++ b/dbflute_introdb/templates/doc/ControlDocument.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/doc/html/datamodel.vm
+++ b/dbflute_introdb/templates/doc/html/datamodel.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/doc/html/diffmodel.vm
+++ b/dbflute_introdb/templates/doc/html/diffmodel.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/doc/html/propmodel.vm
+++ b/dbflute_introdb/templates/doc/html/propmodel.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/doc/html/table.vm
+++ b/dbflute_introdb/templates/doc/html/table.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/ControlGenerateJava.vm
+++ b/dbflute_introdb/templates/om/ControlGenerateJava.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/ControlGenerateScala.vm
+++ b/dbflute_introdb/templates/om/ControlGenerateScala.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/ControlSql2EntityJava.vm
+++ b/dbflute_introdb/templates/om/ControlSql2EntityJava.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/ControlSql2EntityScala.vm
+++ b/dbflute_introdb/templates/om/ControlSql2EntityScala.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/allcommon/CDef.vm
+++ b/dbflute_introdb/templates/om/java/allcommon/CDef.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/allcommon/DBCurrent.vm
+++ b/dbflute_introdb/templates/om/java/allcommon/DBCurrent.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/allcommon/DBFluteConfig.vm
+++ b/dbflute_introdb/templates/om/java/allcommon/DBFluteConfig.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/allcommon/DBFluteInitializer.vm
+++ b/dbflute_introdb/templates/om/java/allcommon/DBFluteInitializer.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/allcommon/DBMetaInstanceHandler.vm
+++ b/dbflute_introdb/templates/om/java/allcommon/DBMetaInstanceHandler.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/allcommon/EntityDefinedCommonColumn.vm
+++ b/dbflute_introdb/templates/om/java/allcommon/EntityDefinedCommonColumn.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/allcommon/ImplementedBehaviorSelector.vm
+++ b/dbflute_introdb/templates/om/java/allcommon/ImplementedBehaviorSelector.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/allcommon/ImplementedCommonColumnAutoSetupper.vm
+++ b/dbflute_introdb/templates/om/java/allcommon/ImplementedCommonColumnAutoSetupper.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/allcommon/ImplementedInvokerAssistant.vm
+++ b/dbflute_introdb/templates/om/java/allcommon/ImplementedInvokerAssistant.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/allcommon/ImplementedSqlClauseCreator.vm
+++ b/dbflute_introdb/templates/om/java/allcommon/ImplementedSqlClauseCreator.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/allcommon/container/cdi/CDIDBFluteModule.vm
+++ b/dbflute_introdb/templates/om/java/allcommon/container/cdi/CDIDBFluteModule.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/allcommon/container/cdi/ExtensionConfig.vm
+++ b/dbflute_introdb/templates/om/java/allcommon/container/cdi/ExtensionConfig.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/allcommon/container/guice/GuiceDBFluteModule.vm
+++ b/dbflute_introdb/templates/om/java/allcommon/container/guice/GuiceDBFluteModule.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/allcommon/container/lasta/DBFluteDiXml.vm
+++ b/dbflute_introdb/templates/om/java/allcommon/container/lasta/DBFluteDiXml.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/allcommon/container/seasar/DBFluteDicon.vm
+++ b/dbflute_introdb/templates/om/java/allcommon/container/seasar/DBFluteDicon.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/allcommon/container/spring/SpringDBFluteBeans.vm
+++ b/dbflute_introdb/templates/om/java/allcommon/container/spring/SpringDBFluteBeans.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/allcommon/container/spring/SpringDBFluteBeansJavaConfig.vm
+++ b/dbflute_introdb/templates/om/java/allcommon/container/spring/SpringDBFluteBeansJavaConfig.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/bsbhv/BaseBhv.vm
+++ b/dbflute_introdb/templates/om/java/bsbhv/BaseBhv.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/bsbhv/ReferrerLoader.vm
+++ b/dbflute_introdb/templates/om/java/bsbhv/ReferrerLoader.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/bsbhv/cursor/BsTypeSafeCursor.vm
+++ b/dbflute_introdb/templates/om/java/bsbhv/cursor/BsTypeSafeCursor.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/bsbhv/cursor/BsTypeSafeCursorHandler.vm
+++ b/dbflute_introdb/templates/om/java/bsbhv/cursor/BsTypeSafeCursorHandler.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/bsbhv/pmbean/BsParameterBean.vm
+++ b/dbflute_introdb/templates/om/java/bsbhv/pmbean/BsParameterBean.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/bsentity/BaseEntity.vm
+++ b/dbflute_introdb/templates/om/java/bsentity/BaseEntity.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/bsentity/dbmeta/DBMetaImpl.vm
+++ b/dbflute_introdb/templates/om/java/bsentity/dbmeta/DBMetaImpl.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/cbean/AbstractBsConditionQuery.vm
+++ b/dbflute_introdb/templates/om/java/cbean/AbstractBsConditionQuery.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/cbean/BsConditionBean.vm
+++ b/dbflute_introdb/templates/om/java/cbean/BsConditionBean.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/cbean/BsConditionInlineQuery.vm
+++ b/dbflute_introdb/templates/om/java/cbean/BsConditionInlineQuery.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/cbean/BsConditionQuery.vm
+++ b/dbflute_introdb/templates/om/java/cbean/BsConditionQuery.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/cbean/ExConditionBean.vm
+++ b/dbflute_introdb/templates/om/java/cbean/ExConditionBean.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/cbean/ExConditionQuery.vm
+++ b/dbflute_introdb/templates/om/java/cbean/ExConditionQuery.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/cbean/NestSelectSetupper.vm
+++ b/dbflute_introdb/templates/om/java/cbean/NestSelectSetupper.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/exbhv/ExtendedBhv.vm
+++ b/dbflute_introdb/templates/om/java/exbhv/ExtendedBhv.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/exbhv/cursor/ExTypeSafeCursor.vm
+++ b/dbflute_introdb/templates/om/java/exbhv/cursor/ExTypeSafeCursor.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/exbhv/cursor/ExTypeSafeCursorHandler.vm
+++ b/dbflute_introdb/templates/om/java/exbhv/cursor/ExTypeSafeCursorHandler.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/exbhv/pmbean/ExParameterBean.vm
+++ b/dbflute_introdb/templates/om/java/exbhv/pmbean/ExParameterBean.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/exentity/ExtendedEntity.vm
+++ b/dbflute_introdb/templates/om/java/exentity/ExtendedEntity.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/other/hibernate/allcommon/HibernateAccessContext.vm
+++ b/dbflute_introdb/templates/om/java/other/hibernate/allcommon/HibernateAccessContext.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/other/hibernate/allcommon/HibernateCDef.vm
+++ b/dbflute_introdb/templates/om/java/other/hibernate/allcommon/HibernateCDef.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/other/hibernate/allcommon/HibernateCommonColumnAutoSetupper.vm
+++ b/dbflute_introdb/templates/om/java/other/hibernate/allcommon/HibernateCommonColumnAutoSetupper.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/other/hibernate/allcommon/HibernateEntity.vm
+++ b/dbflute_introdb/templates/om/java/other/hibernate/allcommon/HibernateEntity.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/other/hibernate/allcommon/HibernateEntityDefinedCommonColumn.vm
+++ b/dbflute_introdb/templates/om/java/other/hibernate/allcommon/HibernateEntityDefinedCommonColumn.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/other/hibernate/bsentity/HibernateBaseEntity.vm
+++ b/dbflute_introdb/templates/om/java/other/hibernate/bsentity/HibernateBaseEntity.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/other/hibernate/exentity/HibernateExtendedEntity.vm
+++ b/dbflute_introdb/templates/om/java/other/hibernate/exentity/HibernateExtendedEntity.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/other/hibernate/hibernate-Control.vm
+++ b/dbflute_introdb/templates/om/java/other/hibernate/hibernate-Control.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/bhvap/BhvApBaseBhv.vm
+++ b/dbflute_introdb/templates/om/java/plugin/bhvap/BhvApBaseBhv.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/bhvap/BhvApExtendedBhv.vm
+++ b/dbflute_introdb/templates/om/java/plugin/bhvap/BhvApExtendedBhv.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/bhvap/ControlBhvApJava.vm
+++ b/dbflute_introdb/templates/om/java/plugin/bhvap/ControlBhvApJava.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/bhvap/container/guice/BhvApGuiceDBFluteModule.vm
+++ b/dbflute_introdb/templates/om/java/plugin/bhvap/container/guice/BhvApGuiceDBFluteModule.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/bhvap/container/lucy/BhvApLucyDBFluteBeans.vm
+++ b/dbflute_introdb/templates/om/java/plugin/bhvap/container/lucy/BhvApLucyDBFluteBeans.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/bhvap/container/seasar/BhvApDBFluteDicon.vm
+++ b/dbflute_introdb/templates/om/java/plugin/bhvap/container/seasar/BhvApDBFluteDicon.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/bhvap/container/spring/BhvApSpringDBFluteBeans.vm
+++ b/dbflute_introdb/templates/om/java/plugin/bhvap/container/spring/BhvApSpringDBFluteBeans.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/flexdto/ControlPluginFlexDtoGenerate.vm
+++ b/dbflute_introdb/templates/om/java/plugin/flexdto/ControlPluginFlexDtoGenerate.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/flexdto/ControlPluginFlexDtoSql2Entity.vm
+++ b/dbflute_introdb/templates/om/java/plugin/flexdto/ControlPluginFlexDtoSql2Entity.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/flexdto/FlexDtoBaseEntity.vm
+++ b/dbflute_introdb/templates/om/java/plugin/flexdto/FlexDtoBaseEntity.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/flexdto/FlexDtoExtendedEntity.vm
+++ b/dbflute_introdb/templates/om/java/plugin/flexdto/FlexDtoExtendedEntity.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/lastaflute/ControlFreeGenLastaJava.vm
+++ b/dbflute_introdb/templates/om/java/plugin/lastaflute/ControlFreeGenLastaJava.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/lastaflute/LaAppCDef.vm
+++ b/dbflute_introdb/templates/om/java/plugin/lastaflute/LaAppCDef.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/lastaflute/LaDocHtml.vm
+++ b/dbflute_introdb/templates/om/java/plugin/lastaflute/LaDocHtml.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/lastaflute/LaHtmlPath.vm
+++ b/dbflute_introdb/templates/om/java/plugin/lastaflute/LaHtmlPath.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/lastaflute/LaMailFlute.vm
+++ b/dbflute_introdb/templates/om/java/plugin/lastaflute/LaMailFlute.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/lastaflute/LaPmTemplate.vm
+++ b/dbflute_introdb/templates/om/java/plugin/lastaflute/LaPmTemplate.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/lastaflute/LaSystemConfig.vm
+++ b/dbflute_introdb/templates/om/java/plugin/lastaflute/LaSystemConfig.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/lastaflute/LaUserMessages.vm
+++ b/dbflute_introdb/templates/om/java/plugin/lastaflute/LaUserMessages.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/lastaflute/doc/LaActionDocHtml.vm
+++ b/dbflute_introdb/templates/om/java/plugin/lastaflute/doc/LaActionDocHtml.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/lastaflute/doc/LaActionDocHtmlTypeDocMeta.vm
+++ b/dbflute_introdb/templates/om/java/plugin/lastaflute/doc/LaActionDocHtmlTypeDocMeta.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/lastaflute/doc/LaAppCDefDocHtml.vm
+++ b/dbflute_introdb/templates/om/java/plugin/lastaflute/doc/LaAppCDefDocHtml.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/lastaflute/doc/LaJobDocHtml.vm
+++ b/dbflute_introdb/templates/om/java/plugin/lastaflute/doc/LaJobDocHtml.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/lastaflute/doc/LaMailFluteDocHtml.vm
+++ b/dbflute_introdb/templates/om/java/plugin/lastaflute/doc/LaMailFluteDocHtml.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/lastaflute/doc/LaPmTemplateDocHtml.vm
+++ b/dbflute_introdb/templates/om/java/plugin/lastaflute/doc/LaPmTemplateDocHtml.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/lastaflute/shared/LaClientClsDfProp.vm
+++ b/dbflute_introdb/templates/om/java/plugin/lastaflute/shared/LaClientClsDfProp.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/simpledto/ControlPluginSimpleDtoGenerate.vm
+++ b/dbflute_introdb/templates/om/java/plugin/simpledto/ControlPluginSimpleDtoGenerate.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/simpledto/ControlPluginSimpleDtoSql2Entity.vm
+++ b/dbflute_introdb/templates/om/java/plugin/simpledto/ControlPluginSimpleDtoSql2Entity.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/simpledto/SimpleCDef.vm
+++ b/dbflute_introdb/templates/om/java/plugin/simpledto/SimpleCDef.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/simpledto/SimpleDtoBaseEntity.vm
+++ b/dbflute_introdb/templates/om/java/plugin/simpledto/SimpleDtoBaseEntity.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/simpledto/SimpleDtoExtendedEntity.vm
+++ b/dbflute_introdb/templates/om/java/plugin/simpledto/SimpleDtoExtendedEntity.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/simpledto/mapper/SimpleDtoBaseMapper.vm
+++ b/dbflute_introdb/templates/om/java/plugin/simpledto/mapper/SimpleDtoBaseMapper.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/dbflute_introdb/templates/om/java/plugin/simpledto/mapper/SimpleDtoExtendedMapper.vm
+++ b/dbflute_introdb/templates/om/java/plugin/simpledto/mapper/SimpleDtoExtendedMapper.vm
@@ -1,5 +1,5 @@
 ##
-## Copyright 2014-2021 the original author or authors.
+## Copyright 2014-2026 the original author or authors.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/IntroBoot.java
+++ b/src/main/java/org/dbflute/intro/IntroBoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/client/ClientPhysicalLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/client/ClientPhysicalLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/client/ClientReadLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/client/ClientReadLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/client/ClientUpdateLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/client/ClientUpdateLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/client/projectinfra/ClientProjectInfraReadLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/client/projectinfra/ClientProjectInfraReadLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/context/AccessContextLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/context/AccessContextLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/core/FlutyFileLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/core/FlutyFileLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/core/MapStringLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/core/MapStringLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/core/PublicPropertiesLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/core/PublicPropertiesLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/dfprop/DfpropPhysicalLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/dfprop/DfpropPhysicalLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/dfprop/DfpropReadLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/dfprop/DfpropReadLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/dfprop/DfpropUpdateLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/dfprop/DfpropUpdateLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/dfprop/TestConnectionLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/dfprop/TestConnectionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/dfprop/basic/BasicInfoLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/dfprop/basic/BasicInfoLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/dfprop/database/DatabaseInfoLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/dfprop/database/DatabaseInfoLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/dfprop/schemapolicy/DfpropSchemaPolicyDefLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/dfprop/schemapolicy/DfpropSchemaPolicyDefLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/dfprop/schemapolicy/DfpropSchemaPolicyReadLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/dfprop/schemapolicy/DfpropSchemaPolicyReadLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/dfprop/schemapolicy/DfpropSchemaPolicyUpdateLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/dfprop/schemapolicy/DfpropSchemaPolicyUpdateLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/dfprop/schemapolicy/file/DfpropSchemaPolicyFileCommentLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/dfprop/schemapolicy/file/DfpropSchemaPolicyFileCommentLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/dfprop/schemapolicy/file/DfpropSchemaPolicyFileReplaceLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/dfprop/schemapolicy/file/DfpropSchemaPolicyFileReplaceLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/document/DocumentAuthorLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/document/DocumentAuthorLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/document/DocumentDisplayLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/document/DocumentDisplayLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/document/DocumentPhysicalLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/document/DocumentPhysicalLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/document/decomment/DocumentDecommentPhysicalLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/document/decomment/DocumentDecommentPhysicalLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/document/hacomment/DocumentHacommentPhysicalLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/document/hacomment/DocumentHacommentPhysicalLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/engine/EngineInstallLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/engine/EngineInstallLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/engine/EnginePhysicalLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/engine/EnginePhysicalLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/engine/EngineReadLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/engine/EngineReadLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/exception/DirNotFoundException.java
+++ b/src/main/java/org/dbflute/intro/app/logic/exception/DirNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/exception/GitBranchGetFailureException.java
+++ b/src/main/java/org/dbflute/intro/app/logic/exception/GitBranchGetFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/exception/PublicPropertiesLoadingFailureException.java
+++ b/src/main/java/org/dbflute/intro/app/logic/exception/PublicPropertiesLoadingFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/exception/SubjectableMapTypeNotExistException.java
+++ b/src/main/java/org/dbflute/intro/app/logic/exception/SubjectableMapTypeNotExistException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/intro/IntroPhysicalLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/intro/IntroPhysicalLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/intro/IntroReadLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/intro/IntroReadLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/intro/IntroSystemLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/intro/IntroSystemLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/log/LogPhysicalLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/log/LogPhysicalLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/playsql/PlaysqlPhysicalLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/playsql/PlaysqlPhysicalLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/playsql/data/PlaysqlDataLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/playsql/data/PlaysqlDataLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/playsql/migration/PlaysqlMigrationPhysicalLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/playsql/migration/PlaysqlMigrationPhysicalLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/playsql/migration/PlaysqlMigrationUpdateLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/playsql/migration/PlaysqlMigrationUpdateLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/playsql/migration/info/PlaysqlMigrationReadLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/playsql/migration/info/PlaysqlMigrationReadLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/playsql/migration/info/ref/PlaysqlMigrationAlterSqlReturn.java
+++ b/src/main/java/org/dbflute/intro/app/logic/playsql/migration/info/ref/PlaysqlMigrationAlterSqlReturn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/playsql/migration/info/ref/PlaysqlMigrationCheckedZipReturn.java
+++ b/src/main/java/org/dbflute/intro/app/logic/playsql/migration/info/ref/PlaysqlMigrationCheckedZipReturn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/playsql/migration/info/ref/PlaysqlMigrationDirReturn.java
+++ b/src/main/java/org/dbflute/intro/app/logic/playsql/migration/info/ref/PlaysqlMigrationDirReturn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/playsql/migration/info/ref/PlaysqlMigrationNgMarkFileReturn.java
+++ b/src/main/java/org/dbflute/intro/app/logic/playsql/migration/info/ref/PlaysqlMigrationNgMarkFileReturn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/playsql/migration/info/ref/PlaysqlMigrationUnreleasedDirReturn.java
+++ b/src/main/java/org/dbflute/intro/app/logic/playsql/migration/info/ref/PlaysqlMigrationUnreleasedDirReturn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/logic/task/TaskExecutionLogic.java
+++ b/src/main/java/org/dbflute/intro/app/logic/task/TaskExecutionLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/ClientModel.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/ClientModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/ExtlibFile.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/ExtlibFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/ProjectInfra.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/ProjectInfra.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/basic/BasicInfoMap.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/basic/BasicInfoMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/database/DatabaseInfoMap.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/database/DatabaseInfoMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/database/DbConnectionBox.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/database/DbConnectionBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/database/various/AdditionalSchemaMap.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/database/various/AdditionalSchemaMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/document/DocumentMap.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/document/DocumentMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/document/LittleAdjustmentMap.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/document/LittleAdjustmentMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/document/NeighborhoodSchemaHtmlMap.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/document/NeighborhoodSchemaHtmlMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/document/SchemaDiagramMap.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/document/SchemaDiagramMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/document/SchemaPolicyColumnMap.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/document/SchemaPolicyColumnMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/document/SchemaPolicyMap.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/document/SchemaPolicyMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/document/SchemaPolicyStatement.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/document/SchemaPolicyStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/document/SchemaPolicyTableMap.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/document/SchemaPolicyTableMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/document/SchemaPolicyTargetSetting.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/document/SchemaPolicyTargetSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/document/SchemaPolicyWholeMap.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/document/SchemaPolicyWholeMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/document/SchemaSyncCheckMap.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/document/SchemaSyncCheckMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/outsidesql/OutsideSqlMap.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/outsidesql/OutsideSqlMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/reps/AdditionalUserMap.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/reps/AdditionalUserMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/reps/ReplaceSchemaMap.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/reps/ReplaceSchemaMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/model/client/reps/SystemUserMap.java
+++ b/src/main/java/org/dbflute/intro/app/model/client/reps/SystemUserMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/SwaggerAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/SwaggerAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/base/CsrfTokenVerifySkip.java
+++ b/src/main/java/org/dbflute/intro/app/web/base/CsrfTokenVerifySkip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/base/IntroBaseAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/base/IntroBaseAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/base/cls/IntroClsAssist.java
+++ b/src/main/java/org/dbflute/intro/app/web/base/cls/IntroClsAssist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/base/cls/result/BasicClassificationResult.java
+++ b/src/main/java/org/dbflute/intro/app/web/base/cls/result/BasicClassificationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/base/cls/result/ContainerDefPart.java
+++ b/src/main/java/org/dbflute/intro/app/web/base/cls/result/ContainerDefPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/base/cls/result/DatabaseDefPart.java
+++ b/src/main/java/org/dbflute/intro/app/web/base/cls/result/DatabaseDefPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/base/cls/result/LanguageDefPart.java
+++ b/src/main/java/org/dbflute/intro/app/web/base/cls/result/LanguageDefPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/client/ClientAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/client/ClientAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/client/ClientCreateBody.java
+++ b/src/main/java/org/dbflute/intro/app/web/client/ClientCreateBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/client/ClientUpdateAssist.java
+++ b/src/main/java/org/dbflute/intro/app/web/client/ClientUpdateAssist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/client/list/ClientListAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/client/list/ClientListAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/client/list/ClientRowResult.java
+++ b/src/main/java/org/dbflute/intro/app/web/client/list/ClientRowResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/client/propbase/ClientPropbaseAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/client/propbase/ClientPropbaseAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/client/propbase/ClientPropbaseResult.java
+++ b/src/main/java/org/dbflute/intro/app/web/client/propbase/ClientPropbaseResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/DfpropAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/DfpropAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/DfpropBean.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/DfpropBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/DfpropUpdateBody.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/DfpropUpdateBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/document/DfpropDocumentAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/document/DfpropDocumentAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/document/DfpropDocumentEditBody.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/document/DfpropDocumentEditBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/document/DfpropDocumentResult.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/document/DfpropDocumentResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/DfpropSchemaPolicyEditBody.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/DfpropSchemaPolicyEditBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/DfpropSchemaPolicyResult.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/DfpropSchemaPolicyResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/DfpropSchemapolicyAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/DfpropSchemapolicyAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/statement/DfpropDeleteSchemaPolicyStatementBody.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/statement/DfpropDeleteSchemaPolicyStatementBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/statement/DfpropMoveSchemaPolicyStatementBody.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/statement/DfpropMoveSchemaPolicyStatementBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/statement/DfpropRegisterSchemaPolicyStatementBody.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/statement/DfpropRegisterSchemaPolicyStatementBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/statement/DfpropSchemapolicyStatementAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/statement/DfpropSchemapolicyStatementAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/statement/DfpropSchemapolicyStatementSubjectForm.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/statement/DfpropSchemapolicyStatementSubjectForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/schemasync/DfpropSchemaSyncCheckResult.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/schemasync/DfpropSchemaSyncCheckResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/schemasync/DfpropSchemaSyncEditBody.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/schemasync/DfpropSchemaSyncEditBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/schemasync/DfpropSchemasyncAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/schemasync/DfpropSchemasyncAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/settings/DfpropSettingsAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/settings/DfpropSettingsAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/settings/DfpropSettingsResult.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/settings/DfpropSettingsResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/settings/DfpropSettingsUpdateBody.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/settings/DfpropSettingsUpdateBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/document/DocumentAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/document/DocumentAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/document/HistoryHtmlResult.java
+++ b/src/main/java/org/dbflute/intro/app/web/document/HistoryHtmlResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/document/SchemaHtmlResult.java
+++ b/src/main/java/org/dbflute/intro/app/web/document/SchemaHtmlResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/document/decomment/DecommentMappingSaveBody.java
+++ b/src/main/java/org/dbflute/intro/app/web/document/decomment/DecommentMappingSaveBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/document/decomment/DecommentPickupResult.java
+++ b/src/main/java/org/dbflute/intro/app/web/document/decomment/DecommentPickupResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/document/decomment/DecommentSaveBody.java
+++ b/src/main/java/org/dbflute/intro/app/web/document/decomment/DecommentSaveBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/document/decomment/DocumentDecommentAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/document/decomment/DocumentDecommentAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/document/hacomment/DocumentHacommentAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/document/hacomment/DocumentHacommentAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/document/hacomment/HacommentPickupResult.java
+++ b/src/main/java/org/dbflute/intro/app/web/document/hacomment/HacommentPickupResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/document/hacomment/HacommentSaveBody.java
+++ b/src/main/java/org/dbflute/intro/app/web/document/hacomment/HacommentSaveBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/engine/EngineAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/engine/EngineAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/engine/EngineDownloadBody.java
+++ b/src/main/java/org/dbflute/intro/app/web/engine/EngineDownloadBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/engine/EngineLatestBean.java
+++ b/src/main/java/org/dbflute/intro/app/web/engine/EngineLatestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/engine/EngineLatestBody.java
+++ b/src/main/java/org/dbflute/intro/app/web/engine/EngineLatestBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/intro/IntroAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/intro/IntroAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/log/LogAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/log/LogAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/log/LogBody.java
+++ b/src/main/java/org/dbflute/intro/app/web/log/LogBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/log/LogResult.java
+++ b/src/main/java/org/dbflute/intro/app/web/log/LogResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/playsql/PlaysqlAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/playsql/PlaysqlAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/playsql/PlaysqlBean.java
+++ b/src/main/java/org/dbflute/intro/app/web/playsql/PlaysqlBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/playsql/PlaysqlUpdateBody.java
+++ b/src/main/java/org/dbflute/intro/app/web/playsql/PlaysqlUpdateBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/playsql/data/PlaysqlDataAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/playsql/data/PlaysqlDataAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/playsql/migration/alter/AlterCreateBody.java
+++ b/src/main/java/org/dbflute/intro/app/web/playsql/migration/alter/AlterCreateBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/playsql/migration/alter/AlterSQLResult.java
+++ b/src/main/java/org/dbflute/intro/app/web/playsql/migration/alter/AlterSQLResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/playsql/migration/alter/PlaysqlMigrationAlterAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/playsql/migration/alter/PlaysqlMigrationAlterAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/playsql/migration/alter/PlaysqlMigrationAlterAssist.java
+++ b/src/main/java/org/dbflute/intro/app/web/playsql/migration/alter/PlaysqlMigrationAlterAssist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/task/TaskAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/task/TaskAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/task/TaskExecutionResult.java
+++ b/src/main/java/org/dbflute/intro/app/web/task/TaskExecutionResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/welcome/WelcomeAction.java
+++ b/src/main/java/org/dbflute/intro/app/web/welcome/WelcomeAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/app/web/welcome/WelcomeCreateBody.java
+++ b/src/main/java/org/dbflute/intro/app/web/welcome/WelcomeCreateBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/bizfw/annotation/NotAvailableDecommentServer.java
+++ b/src/main/java/org/dbflute/intro/bizfw/annotation/NotAvailableDecommentServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/bizfw/server/BootingInternetDomain.java
+++ b/src/main/java/org/dbflute/intro/bizfw/server/BootingInternetDomain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/bizfw/tellfailure/ClientAlreadyExistsException.java
+++ b/src/main/java/org/dbflute/intro/bizfw/tellfailure/ClientAlreadyExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/bizfw/tellfailure/ClientCannotDeleteException.java
+++ b/src/main/java/org/dbflute/intro/bizfw/tellfailure/ClientCannotDeleteException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/bizfw/tellfailure/ClientNotFoundException.java
+++ b/src/main/java/org/dbflute/intro/bizfw/tellfailure/ClientNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/bizfw/tellfailure/DatabaseConnectionException.java
+++ b/src/main/java/org/dbflute/intro/bizfw/tellfailure/DatabaseConnectionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/bizfw/tellfailure/DfpropDirNotFoundException.java
+++ b/src/main/java/org/dbflute/intro/bizfw/tellfailure/DfpropDirNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/bizfw/tellfailure/DfpropFileNotFoundException.java
+++ b/src/main/java/org/dbflute/intro/bizfw/tellfailure/DfpropFileNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/bizfw/tellfailure/IntroFileOperationException.java
+++ b/src/main/java/org/dbflute/intro/bizfw/tellfailure/IntroFileOperationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/bizfw/tellfailure/NetworkErrorException.java
+++ b/src/main/java/org/dbflute/intro/bizfw/tellfailure/NetworkErrorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/bizfw/tellfailure/OpenDirNotFoundException.java
+++ b/src/main/java/org/dbflute/intro/bizfw/tellfailure/OpenDirNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/bizfw/tellfailure/PlaysqlFileNotFoundException.java
+++ b/src/main/java/org/dbflute/intro/bizfw/tellfailure/PlaysqlFileNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/bizfw/tellfailure/SchemaPolicyStatementOutOfIndexException.java
+++ b/src/main/java/org/dbflute/intro/bizfw/tellfailure/SchemaPolicyStatementOutOfIndexException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/bizfw/tellfailure/TaskExecuteFailureException.java
+++ b/src/main/java/org/dbflute/intro/bizfw/tellfailure/TaskExecuteFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/bizfw/tellfailure/base/IntroApplicationException.java
+++ b/src/main/java/org/dbflute/intro/bizfw/tellfailure/base/IntroApplicationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/bizfw/util/IntroAssertUtil.java
+++ b/src/main/java/org/dbflute/intro/bizfw/util/IntroAssertUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/bizfw/util/ProcessUtil.java
+++ b/src/main/java/org/dbflute/intro/bizfw/util/ProcessUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/bizfw/util/ZipUtil.java
+++ b/src/main/java/org/dbflute/intro/bizfw/util/ZipUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/allcommon/CDef.java
+++ b/src/main/java/org/dbflute/intro/dbflute/allcommon/CDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/allcommon/DBCurrent.java
+++ b/src/main/java/org/dbflute/intro/dbflute/allcommon/DBCurrent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/allcommon/DBFluteConfig.java
+++ b/src/main/java/org/dbflute/intro/dbflute/allcommon/DBFluteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/allcommon/DBFluteInitializer.java
+++ b/src/main/java/org/dbflute/intro/dbflute/allcommon/DBFluteInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/allcommon/DBMetaInstanceHandler.java
+++ b/src/main/java/org/dbflute/intro/dbflute/allcommon/DBMetaInstanceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/allcommon/EntityDefinedCommonColumn.java
+++ b/src/main/java/org/dbflute/intro/dbflute/allcommon/EntityDefinedCommonColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/allcommon/ImplementedBehaviorSelector.java
+++ b/src/main/java/org/dbflute/intro/dbflute/allcommon/ImplementedBehaviorSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/allcommon/ImplementedCommonColumnAutoSetupper.java
+++ b/src/main/java/org/dbflute/intro/dbflute/allcommon/ImplementedCommonColumnAutoSetupper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/allcommon/ImplementedInvokerAssistant.java
+++ b/src/main/java/org/dbflute/intro/dbflute/allcommon/ImplementedInvokerAssistant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/allcommon/ImplementedSqlClauseCreator.java
+++ b/src/main/java/org/dbflute/intro/dbflute/allcommon/ImplementedSqlClauseCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/bsbhv/BsClsTargetContainerBhv.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsbhv/BsClsTargetContainerBhv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/bsbhv/BsClsTargetDatabaseBhv.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsbhv/BsClsTargetDatabaseBhv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/bsbhv/BsClsTargetLanguageBhv.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsbhv/BsClsTargetLanguageBhv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/bsbhv/loader/LoaderOfClsTargetContainer.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsbhv/loader/LoaderOfClsTargetContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/bsbhv/loader/LoaderOfClsTargetDatabase.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsbhv/loader/LoaderOfClsTargetDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/bsbhv/loader/LoaderOfClsTargetLanguage.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsbhv/loader/LoaderOfClsTargetLanguage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/bsentity/BsClsTargetContainer.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsentity/BsClsTargetContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/bsentity/BsClsTargetDatabase.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsentity/BsClsTargetDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/bsentity/BsClsTargetLanguage.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsentity/BsClsTargetLanguage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/bsentity/dbmeta/ClsTargetContainerDbm.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsentity/dbmeta/ClsTargetContainerDbm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/bsentity/dbmeta/ClsTargetDatabaseDbm.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsentity/dbmeta/ClsTargetDatabaseDbm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/bsentity/dbmeta/ClsTargetLanguageDbm.java
+++ b/src/main/java/org/dbflute/intro/dbflute/bsentity/dbmeta/ClsTargetLanguageDbm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/cbean/ClsTargetContainerCB.java
+++ b/src/main/java/org/dbflute/intro/dbflute/cbean/ClsTargetContainerCB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/cbean/ClsTargetDatabaseCB.java
+++ b/src/main/java/org/dbflute/intro/dbflute/cbean/ClsTargetDatabaseCB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/cbean/ClsTargetLanguageCB.java
+++ b/src/main/java/org/dbflute/intro/dbflute/cbean/ClsTargetLanguageCB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/cbean/bs/BsClsTargetContainerCB.java
+++ b/src/main/java/org/dbflute/intro/dbflute/cbean/bs/BsClsTargetContainerCB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/cbean/bs/BsClsTargetDatabaseCB.java
+++ b/src/main/java/org/dbflute/intro/dbflute/cbean/bs/BsClsTargetDatabaseCB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/cbean/bs/BsClsTargetLanguageCB.java
+++ b/src/main/java/org/dbflute/intro/dbflute/cbean/bs/BsClsTargetLanguageCB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/cbean/cq/ClsTargetContainerCQ.java
+++ b/src/main/java/org/dbflute/intro/dbflute/cbean/cq/ClsTargetContainerCQ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/cbean/cq/ClsTargetDatabaseCQ.java
+++ b/src/main/java/org/dbflute/intro/dbflute/cbean/cq/ClsTargetDatabaseCQ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/cbean/cq/ClsTargetLanguageCQ.java
+++ b/src/main/java/org/dbflute/intro/dbflute/cbean/cq/ClsTargetLanguageCQ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/cbean/cq/bs/AbstractBsClsTargetContainerCQ.java
+++ b/src/main/java/org/dbflute/intro/dbflute/cbean/cq/bs/AbstractBsClsTargetContainerCQ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/cbean/cq/bs/AbstractBsClsTargetDatabaseCQ.java
+++ b/src/main/java/org/dbflute/intro/dbflute/cbean/cq/bs/AbstractBsClsTargetDatabaseCQ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/cbean/cq/bs/AbstractBsClsTargetLanguageCQ.java
+++ b/src/main/java/org/dbflute/intro/dbflute/cbean/cq/bs/AbstractBsClsTargetLanguageCQ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/cbean/cq/bs/BsClsTargetContainerCQ.java
+++ b/src/main/java/org/dbflute/intro/dbflute/cbean/cq/bs/BsClsTargetContainerCQ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/cbean/cq/bs/BsClsTargetDatabaseCQ.java
+++ b/src/main/java/org/dbflute/intro/dbflute/cbean/cq/bs/BsClsTargetDatabaseCQ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/cbean/cq/bs/BsClsTargetLanguageCQ.java
+++ b/src/main/java/org/dbflute/intro/dbflute/cbean/cq/bs/BsClsTargetLanguageCQ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/cbean/cq/ciq/ClsTargetContainerCIQ.java
+++ b/src/main/java/org/dbflute/intro/dbflute/cbean/cq/ciq/ClsTargetContainerCIQ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/cbean/cq/ciq/ClsTargetDatabaseCIQ.java
+++ b/src/main/java/org/dbflute/intro/dbflute/cbean/cq/ciq/ClsTargetDatabaseCIQ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/cbean/cq/ciq/ClsTargetLanguageCIQ.java
+++ b/src/main/java/org/dbflute/intro/dbflute/cbean/cq/ciq/ClsTargetLanguageCIQ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/exbhv/ClsTargetContainerBhv.java
+++ b/src/main/java/org/dbflute/intro/dbflute/exbhv/ClsTargetContainerBhv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/exbhv/ClsTargetDatabaseBhv.java
+++ b/src/main/java/org/dbflute/intro/dbflute/exbhv/ClsTargetDatabaseBhv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/exbhv/ClsTargetLanguageBhv.java
+++ b/src/main/java/org/dbflute/intro/dbflute/exbhv/ClsTargetLanguageBhv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/exentity/ClsTargetContainer.java
+++ b/src/main/java/org/dbflute/intro/dbflute/exentity/ClsTargetContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/exentity/ClsTargetDatabase.java
+++ b/src/main/java/org/dbflute/intro/dbflute/exentity/ClsTargetDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/dbflute/exentity/ClsTargetLanguage.java
+++ b/src/main/java/org/dbflute/intro/dbflute/exentity/ClsTargetLanguage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/mylasta/action/IntroLabels.java
+++ b/src/main/java/org/dbflute/intro/mylasta/action/IntroLabels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/mylasta/action/IntroMessages.java
+++ b/src/main/java/org/dbflute/intro/mylasta/action/IntroMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/mylasta/appcls/AppCDef.java
+++ b/src/main/java/org/dbflute/intro/mylasta/appcls/AppCDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/mylasta/direction/IntroConfig.java
+++ b/src/main/java/org/dbflute/intro/mylasta/direction/IntroConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/mylasta/direction/IntroEnv.java
+++ b/src/main/java/org/dbflute/intro/mylasta/direction/IntroEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/mylasta/direction/IntroFwAssistantDirector.java
+++ b/src/main/java/org/dbflute/intro/mylasta/direction/IntroFwAssistantDirector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/mylasta/direction/sponsor/IntroActionAdjustmentProvider.java
+++ b/src/main/java/org/dbflute/intro/mylasta/direction/sponsor/IntroActionAdjustmentProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/mylasta/direction/sponsor/IntroApiFailureHook.java
+++ b/src/main/java/org/dbflute/intro/mylasta/direction/sponsor/IntroApiFailureHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/mylasta/direction/sponsor/IntroCookieResourceProvider.java
+++ b/src/main/java/org/dbflute/intro/mylasta/direction/sponsor/IntroCookieResourceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/mylasta/direction/sponsor/IntroCurtainBeforeHook.java
+++ b/src/main/java/org/dbflute/intro/mylasta/direction/sponsor/IntroCurtainBeforeHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/mylasta/direction/sponsor/IntroSecurityResourceProvider.java
+++ b/src/main/java/org/dbflute/intro/mylasta/direction/sponsor/IntroSecurityResourceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/mylasta/direction/sponsor/IntroTimeResourceProvider.java
+++ b/src/main/java/org/dbflute/intro/mylasta/direction/sponsor/IntroTimeResourceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/mylasta/direction/sponsor/IntroUserLocaleProcessProvider.java
+++ b/src/main/java/org/dbflute/intro/mylasta/direction/sponsor/IntroUserLocaleProcessProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/mylasta/direction/sponsor/IntroUserTimeZoneProcessProvider.java
+++ b/src/main/java/org/dbflute/intro/mylasta/direction/sponsor/IntroUserTimeZoneProcessProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/intro/mylasta/direction/sponsor/introdb/IntroDBInitializer.java
+++ b/src/main/java/org/dbflute/intro/mylasta/direction/sponsor/introdb/IntroDBInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/logic/dfprop/schemapolicy/DfpropSchemaPolicyReadLogicTest.java
+++ b/src/test/java/org/dbflute/intro/app/logic/dfprop/schemapolicy/DfpropSchemaPolicyReadLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/logic/dfprop/schemapolicy/DfpropSchemaPolicyUpdateLogicTest.java
+++ b/src/test/java/org/dbflute/intro/app/logic/dfprop/schemapolicy/DfpropSchemaPolicyUpdateLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/logic/dfprop/schemapolicy/file/DfpropSchemaPolicyFileCommentLogicTest.java
+++ b/src/test/java/org/dbflute/intro/app/logic/dfprop/schemapolicy/file/DfpropSchemaPolicyFileCommentLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/logic/document/DocumentAuthorLogicTest.java
+++ b/src/test/java/org/dbflute/intro/app/logic/document/DocumentAuthorLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/logic/document/decomment/DocumentDecommentPhysicalLogicTest.java
+++ b/src/test/java/org/dbflute/intro/app/logic/document/decomment/DocumentDecommentPhysicalLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/logic/intro/IntroSystemLogicTest.java
+++ b/src/test/java/org/dbflute/intro/app/logic/intro/IntroSystemLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/logic/playsql/migration/info/PlaysqlMigrationReadLogicTest.java
+++ b/src/test/java/org/dbflute/intro/app/logic/playsql/migration/info/PlaysqlMigrationReadLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/model/document/decomment/DfDecoMapFileTest.java
+++ b/src/test/java/org/dbflute/intro/app/model/document/decomment/DfDecoMapFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/web/client/ClientActionTest.java
+++ b/src/test/java/org/dbflute/intro/app/web/client/ClientActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/web/client/list/ClientListActionTest.java
+++ b/src/test/java/org/dbflute/intro/app/web/client/list/ClientListActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/web/client/propbase/ClientPropbaseActionTest.java
+++ b/src/test/java/org/dbflute/intro/app/web/client/propbase/ClientPropbaseActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/web/dfprop/DfpropActionTest.java
+++ b/src/test/java/org/dbflute/intro/app/web/dfprop/DfpropActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/web/dfprop/document/DfpropDocumentActionTest.java
+++ b/src/test/java/org/dbflute/intro/app/web/dfprop/document/DfpropDocumentActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/web/dfprop/schemapolicy/statement/DfpropSchemapolicyStatementActionTest.java
+++ b/src/test/java/org/dbflute/intro/app/web/dfprop/schemapolicy/statement/DfpropSchemapolicyStatementActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/web/document/DocumentActionTest.java
+++ b/src/test/java/org/dbflute/intro/app/web/document/DocumentActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/web/document/decomment/DocumentDecommentActionTest.java
+++ b/src/test/java/org/dbflute/intro/app/web/document/decomment/DocumentDecommentActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/web/document/hacomment/DocumentHacommentActionTest.java
+++ b/src/test/java/org/dbflute/intro/app/web/document/hacomment/DocumentHacommentActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/web/intro/IntroActionTest.java
+++ b/src/test/java/org/dbflute/intro/app/web/intro/IntroActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/web/log/LogActionTest.java
+++ b/src/test/java/org/dbflute/intro/app/web/log/LogActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/web/playsql/PlaysqlActionTest.java
+++ b/src/test/java/org/dbflute/intro/app/web/playsql/PlaysqlActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/web/playsql/migration/alter/PlaysqlMigrationAlterActionTest.java
+++ b/src/test/java/org/dbflute/intro/app/web/playsql/migration/alter/PlaysqlMigrationAlterActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/web/settings/SettingsActionTest.java
+++ b/src/test/java/org/dbflute/intro/app/web/settings/SettingsActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/app/web/task/TaskActionTest.java
+++ b/src/test/java/org/dbflute/intro/app/web/task/TaskActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/bizfw/code/CodeManagementTest.java
+++ b/src/test/java/org/dbflute/intro/bizfw/code/CodeManagementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/bizfw/code/LicenseManagementTest.java
+++ b/src/test/java/org/dbflute/intro/bizfw/code/LicenseManagementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import org.lastaflute.di.exception.IORuntimeException;
  */
 public class LicenseManagementTest extends PlainTestCase {
 
-    private static final String COPYRIGHT = "Copyright 2014-2025 the original author or authors.";
+    private static final String COPYRIGHT = "Copyright 2014-2026 the original author or authors.";
 
     // ===================================================================================
     //                                                                      License Header

--- a/src/test/java/org/dbflute/intro/mylasta/IntroActionDefTest.java
+++ b/src/test/java/org/dbflute/intro/mylasta/IntroActionDefTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/mylasta/IntroLastaDocTest.java
+++ b/src/test/java/org/dbflute/intro/mylasta/IntroLastaDocTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/mylasta/direction/CipherSetupTest.java
+++ b/src/test/java/org/dbflute/intro/mylasta/direction/CipherSetupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/dbflute/intro/unit/UnitIntroTestCase.java
+++ b/src/test/java/org/dbflute/intro/unit/UnitIntroTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## 概要

DBFluteテンプレートファイル（.vm）およびソースコードのライセンスヘッダーを2014-2021から2014-2026に更新しました。

## 変更内容

- 330個のファイルのライセンスヘッダーを更新
  - DBFluteテンプレートファイル（87個の.vmファイル）
  - Javaソースファイル
  - TypeScriptファイル
  - LICENSE_HEADERファイル
- これにより、今後DBFluteエンジンで生成されるファイルは最新のライセンスヘッダーを持つようになります

## 確認済み

- ✅ FreeGenで差分がないこと
- ✅ licenseHeaderテストが通ること

## 関連issue

Closes #552