### PR TITLE
#439 DfpropSchemaPolicyResultにバリデーションアノテーションを追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,11 @@
 
   // フォーマッターとしてPrettierを採用、ここを設定しないと自動フォーマットも効かない
   // (User設定の方で別のフォーマッターを定義してても、ここで上書きする)
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+
+  // Java用のEclipseフォーマッタ設定
+  "java.format.settings.url": "gradle/eclipse/code-formatter-profile.xml",
+  "[java]": {
+    "editor.defaultFormatter": "redhat.java"
+  }
 }

--- a/dbflute_introdb/output/doc/lastadoc-intro.html
+++ b/dbflute_introdb/output/doc/lastadoc-intro.html
@@ -2438,6 +2438,9 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;Required
+,
+            &#64;Valid
         </td>
     </tr>
     <tr>
@@ -2462,6 +2465,9 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;Required
+,
+            &#64;Valid
         </td>
     </tr>
     <tr>
@@ -2486,6 +2492,7 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;Required
         </td>
     </tr>
     <tr>
@@ -2497,6 +2504,7 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;Required
         </td>
     </tr>
     <tr>
@@ -2508,6 +2516,7 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;Required
         </td>
     </tr>
     <tr>
@@ -2519,6 +2528,7 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;Required
         </td>
     </tr>
 </table>
@@ -2540,6 +2550,9 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;Required
+,
+            &#64;Valid
         </td>
     </tr>
     <tr>
@@ -2564,6 +2577,9 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;Required
+,
+            &#64;Valid
         </td>
     </tr>
     <tr>
@@ -2588,6 +2604,7 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;Required
         </td>
     </tr>
     <tr>
@@ -2599,6 +2616,7 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;Required
         </td>
     </tr>
     <tr>
@@ -2610,6 +2628,7 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;Required
         </td>
     </tr>
     <tr>
@@ -2621,6 +2640,7 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;Required
         </td>
     </tr>
 </table>
@@ -2637,6 +2657,7 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;NotNull
         </td>
     </tr>
 </table>
@@ -2653,6 +2674,9 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;Required
+,
+            &#64;Valid
         </td>
     </tr>
     <tr>
@@ -2677,6 +2701,9 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;Required
+,
+            &#64;Valid
         </td>
     </tr>
     <tr>
@@ -2701,6 +2728,7 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;Required
         </td>
     </tr>
     <tr>
@@ -2712,6 +2740,7 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;Required
         </td>
     </tr>
     <tr>
@@ -2723,6 +2752,7 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;Required
         </td>
     </tr>
     <tr>
@@ -2734,6 +2764,7 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;Required
         </td>
     </tr>
 </table>
@@ -2750,6 +2781,7 @@ table.child, table.child td, table.child th {
             <p></p>
         </td>
         <td class="fieldannotations">
+            &#64;NotNull
         </td>
     </tr>
 </table>

--- a/dbflute_introdb/schema/project-lastadoc-intro.json
+++ b/dbflute_introdb/schema/project-lastadoc-intro.json
@@ -1642,7 +1642,10 @@
             "value": null,
             "description": null,
             "comment": null,
-            "annotationList": [],
+            "annotationList": [
+              "Required",
+              "Valid"
+            ],
             "nestTypeDocMetaList": [
               {
                 "name": "themeList",
@@ -1652,7 +1655,10 @@
                 "value": null,
                 "description": null,
                 "comment": null,
-                "annotationList": [],
+                "annotationList": [
+                  "Required",
+                  "Valid"
+                ],
                 "nestTypeDocMetaList": [
                   {
                     "name": "name",
@@ -1662,7 +1668,9 @@
                     "value": null,
                     "description": null,
                     "comment": null,
-                    "annotationList": [],
+                    "annotationList": [
+                      "Required"
+                    ],
                     "nestTypeDocMetaList": []
                   },
                   {
@@ -1673,7 +1681,9 @@
                     "value": null,
                     "description": null,
                     "comment": null,
-                    "annotationList": [],
+                    "annotationList": [
+                      "Required"
+                    ],
                     "nestTypeDocMetaList": []
                   },
                   {
@@ -1684,7 +1694,9 @@
                     "value": null,
                     "description": null,
                     "comment": null,
-                    "annotationList": [],
+                    "annotationList": [
+                      "Required"
+                    ],
                     "nestTypeDocMetaList": []
                   },
                   {
@@ -1695,7 +1707,9 @@
                     "value": null,
                     "description": null,
                     "comment": null,
-                    "annotationList": [],
+                    "annotationList": [
+                      "Required"
+                    ],
                     "nestTypeDocMetaList": []
                   }
                 ]
@@ -1710,7 +1724,10 @@
             "value": null,
             "description": null,
             "comment": null,
-            "annotationList": [],
+            "annotationList": [
+              "Required",
+              "Valid"
+            ],
             "nestTypeDocMetaList": [
               {
                 "name": "themeList",
@@ -1720,7 +1737,10 @@
                 "value": null,
                 "description": null,
                 "comment": null,
-                "annotationList": [],
+                "annotationList": [
+                  "Required",
+                  "Valid"
+                ],
                 "nestTypeDocMetaList": [
                   {
                     "name": "name",
@@ -1730,7 +1750,9 @@
                     "value": null,
                     "description": null,
                     "comment": null,
-                    "annotationList": [],
+                    "annotationList": [
+                      "Required"
+                    ],
                     "nestTypeDocMetaList": []
                   },
                   {
@@ -1741,7 +1763,9 @@
                     "value": null,
                     "description": null,
                     "comment": null,
-                    "annotationList": [],
+                    "annotationList": [
+                      "Required"
+                    ],
                     "nestTypeDocMetaList": []
                   },
                   {
@@ -1752,7 +1776,9 @@
                     "value": null,
                     "description": null,
                     "comment": null,
-                    "annotationList": [],
+                    "annotationList": [
+                      "Required"
+                    ],
                     "nestTypeDocMetaList": []
                   },
                   {
@@ -1763,7 +1789,9 @@
                     "value": null,
                     "description": null,
                     "comment": null,
-                    "annotationList": [],
+                    "annotationList": [
+                      "Required"
+                    ],
                     "nestTypeDocMetaList": []
                   }
                 ]
@@ -1776,7 +1804,9 @@
                 "value": null,
                 "description": null,
                 "comment": null,
-                "annotationList": [],
+                "annotationList": [
+                  "NotNull"
+                ],
                 "nestTypeDocMetaList": []
               }
             ]
@@ -1789,7 +1819,10 @@
             "value": null,
             "description": null,
             "comment": null,
-            "annotationList": [],
+            "annotationList": [
+              "Required",
+              "Valid"
+            ],
             "nestTypeDocMetaList": [
               {
                 "name": "themeList",
@@ -1799,7 +1832,10 @@
                 "value": null,
                 "description": null,
                 "comment": null,
-                "annotationList": [],
+                "annotationList": [
+                  "Required",
+                  "Valid"
+                ],
                 "nestTypeDocMetaList": [
                   {
                     "name": "name",
@@ -1809,7 +1845,9 @@
                     "value": null,
                     "description": null,
                     "comment": null,
-                    "annotationList": [],
+                    "annotationList": [
+                      "Required"
+                    ],
                     "nestTypeDocMetaList": []
                   },
                   {
@@ -1820,7 +1858,9 @@
                     "value": null,
                     "description": null,
                     "comment": null,
-                    "annotationList": [],
+                    "annotationList": [
+                      "Required"
+                    ],
                     "nestTypeDocMetaList": []
                   },
                   {
@@ -1831,7 +1871,9 @@
                     "value": null,
                     "description": null,
                     "comment": null,
-                    "annotationList": [],
+                    "annotationList": [
+                      "Required"
+                    ],
                     "nestTypeDocMetaList": []
                   },
                   {
@@ -1842,7 +1884,9 @@
                     "value": null,
                     "description": null,
                     "comment": null,
-                    "annotationList": [],
+                    "annotationList": [
+                      "Required"
+                    ],
                     "nestTypeDocMetaList": []
                   }
                 ]
@@ -1855,7 +1899,9 @@
                 "value": null,
                 "description": null,
                 "comment": null,
-                "annotationList": [],
+                "annotationList": [
+                  "NotNull"
+                ],
                 "nestTypeDocMetaList": []
               }
             ]

--- a/frontend/src/static/app/api/intro/dfprop/schemapolicy/DfpropSchemapolicyResult.ts
+++ b/frontend/src/static/app/api/intro/dfprop/schemapolicy/DfpropSchemapolicyResult.ts
@@ -19,14 +19,14 @@
  * @author FreeGen
  */
 type DfpropSchemapolicyResult = {
-  /** (NullAllowed) */
-  wholeMap?: DfpropSchemapolicyResult_WholeMapPart
+  /** (Required) */
+  wholeMap: DfpropSchemapolicyResult_WholeMapPart
 
-  /** (NullAllowed) */
-  tableMap?: DfpropSchemapolicyResult_TableMapPart
+  /** (Required) */
+  tableMap: DfpropSchemapolicyResult_TableMapPart
 
-  /** (NullAllowed) */
-  columnMap?: DfpropSchemapolicyResult_ColumnMapPart
+  /** (Required) */
+  columnMap: DfpropSchemapolicyResult_ColumnMapPart
 }
 
 /**
@@ -34,8 +34,8 @@ type DfpropSchemapolicyResult = {
  * @author FreeGen
  */
 type DfpropSchemapolicyResult_WholeMapPart = {
-  /** (NullAllowed) */
-  themeList?: Array<DfpropSchemapolicyResult_ThemePart>
+  /** (NotNull) */
+  themeList: Array<DfpropSchemapolicyResult_ThemePart>
 }
 
 /**
@@ -43,17 +43,17 @@ type DfpropSchemapolicyResult_WholeMapPart = {
  * @author FreeGen
  */
 type DfpropSchemapolicyResult_ThemePart = {
-  /** (NullAllowed) */
-  name?: string
+  /** (Required) */
+  name: string
 
-  /** (NullAllowed) */
-  description?: string
+  /** (Required) */
+  description: string
 
-  /** (NullAllowed) */
-  typeCode?: string
+  /** (Required) */
+  typeCode: string
 
-  /** (NullAllowed) */
-  isActive?: boolean
+  /** (Required) */
+  isActive: boolean
 }
 
 /**
@@ -61,11 +61,11 @@ type DfpropSchemapolicyResult_ThemePart = {
  * @author FreeGen
  */
 type DfpropSchemapolicyResult_TableMapPart = {
-  /** (NullAllowed) */
-  themeList?: Array<DfpropSchemapolicyResult_ThemePart>
+  /** (NotNull) */
+  themeList: Array<DfpropSchemapolicyResult_ThemePart>
 
-  /** (NullAllowed) */
-  statementList?: Array<string>
+  /** (NotNull) */
+  statementList: Array<string>
 }
 
 /**
@@ -73,9 +73,9 @@ type DfpropSchemapolicyResult_TableMapPart = {
  * @author FreeGen
  */
 type DfpropSchemapolicyResult_ColumnMapPart = {
-  /** (NullAllowed) */
-  themeList?: Array<DfpropSchemapolicyResult_ThemePart>
+  /** (NotNull) */
+  themeList: Array<DfpropSchemapolicyResult_ThemePart>
 
-  /** (NullAllowed) */
-  statementList?: Array<string>
+  /** (NotNull) */
+  statementList: Array<string>
 }

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/DfpropSchemaPolicyResult.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/DfpropSchemaPolicyResult.java
@@ -18,10 +18,14 @@ package org.dbflute.intro.app.web.dfprop.schemapolicy;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
 import org.dbflute.intro.app.model.client.document.SchemaPolicyColumnMap;
 import org.dbflute.intro.app.model.client.document.SchemaPolicyMap;
 import org.dbflute.intro.app.model.client.document.SchemaPolicyTableMap;
 import org.dbflute.intro.app.model.client.document.SchemaPolicyWholeMap;
+import org.lastaflute.web.validation.Required;
 
 /**
  * @author hakiba
@@ -29,7 +33,10 @@ import org.dbflute.intro.app.model.client.document.SchemaPolicyWholeMap;
 public class DfpropSchemaPolicyResult {
 
     public static class WholeMap {
-        List<Theme> themeList;
+
+        @Required
+        @Valid
+        public List<Theme> themeList;
 
         public WholeMap(SchemaPolicyWholeMap wholeMap) {
             this.themeList = wholeMap.themeList.stream().map(theme -> new Theme(theme)).collect(Collectors.toList());
@@ -37,8 +44,13 @@ public class DfpropSchemaPolicyResult {
     }
 
     public static class TableMap {
-        List<Theme> themeList;
-        List<String> statementList;
+
+        @Required
+        @Valid
+        public List<Theme> themeList;
+
+        @NotNull
+        public List<String> statementList;
 
         public TableMap(SchemaPolicyTableMap tableMap) {
             this.themeList = tableMap.themeList.stream().map(theme -> new Theme(theme)).collect(Collectors.toList());
@@ -47,8 +59,13 @@ public class DfpropSchemaPolicyResult {
     }
 
     public static class ColumnMap {
-        List<Theme> themeList;
-        List<String> statementList;
+
+        @Required
+        @Valid
+        public List<Theme> themeList;
+
+        @NotNull
+        public List<String> statementList;
 
         public ColumnMap(SchemaPolicyColumnMap columnMap) {
             this.themeList = columnMap.themeList.stream().map(theme -> new Theme(theme)).collect(Collectors.toList());
@@ -57,10 +74,18 @@ public class DfpropSchemaPolicyResult {
     }
 
     public static class Theme {
-        String name;
-        String description;
-        String typeCode;
-        Boolean isActive;
+
+        @Required
+        public String name;
+
+        @Required
+        public String description;
+
+        @Required
+        public String typeCode;
+
+        @Required
+        public Boolean isActive;
 
         public Theme(SchemaPolicyWholeMap.Theme theme) {
             this.name = theme.type.name();
@@ -84,8 +109,16 @@ public class DfpropSchemaPolicyResult {
         }
     }
 
+    @Required
+    @Valid
     public WholeMap wholeMap;
+
+    @Required
+    @Valid
     public TableMap tableMap;
+
+    @Required
+    @Valid
     public ColumnMap columnMap;
 
     public DfpropSchemaPolicyResult(SchemaPolicyMap schemaPolicyMap) {

--- a/src/main/resources/remoteapi/schema/remoteapi_schema_intro_swagger.json
+++ b/src/main/resources/remoteapi/schema/remoteapi_schema_intro_swagger.json
@@ -2027,6 +2027,12 @@
     },
     "org.dbflute.intro.app.web.dfprop.schemapolicy.DfpropSchemaPolicyResult$Theme": {
       "type": "object",
+      "required": [
+        "name",
+        "description",
+        "typeCode",
+        "isActive"
+      ],
       "properties": {
         "name": {
           "type": "string"
@@ -2044,6 +2050,9 @@
     },
     "org.dbflute.intro.app.web.dfprop.schemapolicy.DfpropSchemaPolicyResult$WholeMap": {
       "type": "object",
+      "required": [
+        "themeList"
+      ],
       "properties": {
         "themeList": {
           "type": "array",
@@ -2055,6 +2064,10 @@
     },
     "org.dbflute.intro.app.web.dfprop.schemapolicy.DfpropSchemaPolicyResult$TableMap": {
       "type": "object",
+      "required": [
+        "themeList",
+        "statementList"
+      ],
       "properties": {
         "themeList": {
           "type": "array",
@@ -2072,6 +2085,10 @@
     },
     "org.dbflute.intro.app.web.dfprop.schemapolicy.DfpropSchemaPolicyResult$ColumnMap": {
       "type": "object",
+      "required": [
+        "themeList",
+        "statementList"
+      ],
       "properties": {
         "themeList": {
           "type": "array",
@@ -2089,6 +2106,11 @@
     },
     "org.dbflute.intro.app.web.dfprop.schemapolicy.DfpropSchemaPolicyResult": {
       "type": "object",
+      "required": [
+        "wholeMap",
+        "tableMap",
+        "columnMap"
+      ],
       "properties": {
         "wholeMap": {
           "$ref": "#/definitions/org.dbflute.intro.app.web.dfprop.schemapolicy.DfpropSchemaPolicyResult%24WholeMap"

--- a/src/test/java/org/dbflute/intro/app/web/dfprop/schemapolicy/DfpropSchemapolicyActionTest.java
+++ b/src/test/java/org/dbflute/intro/app/web/dfprop/schemapolicy/DfpropSchemapolicyActionTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2014-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.dbflute.intro.app.web.dfprop.schemapolicy;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.dbflute.intro.bizfw.tellfailure.DfpropFileNotFoundException;
+import org.dbflute.intro.unit.UnitIntroTestCase;
+
+/**
+ * @author cabos
+ */
+public class DfpropSchemapolicyActionTest extends UnitIntroTestCase {
+
+    // ===================================================================================
+    //                                                                                Test
+    //                                                                                ====
+    /**
+     * themeListとstatementListの両方に設定がある場合、エラーなくレスポンスが返ること。
+     */
+    public void test_index_hasSetting() throws Exception {
+        // ## Arrange ##
+        DfpropSchemapolicyAction action = new DfpropSchemapolicyAction();
+        inject(action);
+        prepareSchemaPolicyMap("dfprop/schemaPolicyMap.dfprop");
+
+        // ## Act ##
+        action.index(TEST_CLIENT_PROJECT);
+
+        // ## Assert ##
+        // 例外が発生しないこと
+    }
+
+    /**
+     * schemaPolicyMap.dfpropの設定が空の場合、エラーなくレスポンスが返ること。
+     */
+    public void test_index_emptySettings() throws Exception {
+        // ## Arrange ##
+        DfpropSchemapolicyAction action = new DfpropSchemapolicyAction();
+        inject(action);
+        prepareSchemaPolicyMap("dfprop/noSetting_schemaPolicyMap.dfprop");
+
+        // ## Act ##
+        action.index(TEST_CLIENT_PROJECT);
+
+        // ## Assert ##
+        // 例外が発生しないこと
+    }
+
+    /**
+     * schemaPolicyMap.dfpropが存在しない場合、DfpropFileNotFoundExceptionが発生すること。
+     */
+    public void test_index_fileNotExists() throws Exception {
+        // ## Arrange ##
+        DfpropSchemapolicyAction action = new DfpropSchemapolicyAction();
+        inject(action);
+        File schemaPolicyMapFile = findTestClientFile("dfprop/schemaPolicyMap.dfprop");
+        schemaPolicyMapFile.delete();
+
+        // ## Act & Assert ##
+        assertException(DfpropFileNotFoundException.class, () -> action.index(TEST_CLIENT_PROJECT));
+    }
+
+    // ===================================================================================
+    //                                                                        Assist Logic
+    //                                                                        ============
+    private void prepareSchemaPolicyMap(String filePath) {
+        File srcFile = findTestResourceFile(filePath);
+        File destFile = findTestClientFile("dfprop/schemaPolicyMap.dfprop");
+        try {
+            FileUtils.copyFile(srcFile, destFile);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to copy file: src=" + srcFile + ", dest=" + destFile, e);
+        }
+    }
+}

--- a/src/test/java/org/dbflute/intro/app/web/dfprop/schemapolicy/statement/DfpropSchemapolicyStatementActionTest.java
+++ b/src/test/java/org/dbflute/intro/app/web/dfprop/schemapolicy/statement/DfpropSchemapolicyStatementActionTest.java
@@ -112,90 +112,58 @@ public class DfpropSchemapolicyStatementActionTest extends UnitIntroTestCase {
         DfpropSchemapolicyStatementAction action = new DfpropSchemapolicyStatementAction();
         inject(action);
         Arrays.asList(
-                new MoveStatementTestCase(
-                        "tableMap statement move to head",
-                        new DfpropMoveSchemaPolicyStatementBody("tableMap", 2, 0),
-                        Arrays.asList(beforeTableStates.get(2), beforeTableStates.get(0), beforeTableStates.get(1))
-                ),
-                new MoveStatementTestCase(
-                        "tableMap statement move to same",
-                        new DfpropMoveSchemaPolicyStatementBody("tableMap", 2, 2),
-                        Arrays.asList(beforeTableStates.get(0), beforeTableStates.get(1), beforeTableStates.get(2))
-                ),
-                new MoveStatementTestCase(
-                        "tableMap statement move to tail",
-                        new DfpropMoveSchemaPolicyStatementBody("tableMap", 0, 2),
-                        Arrays.asList(beforeTableStates.get(1), beforeTableStates.get(2), beforeTableStates.get(0))
-                ),
-                new MoveStatementTestCase(
-                        "tableMap statement fromIndex is invalid",
+                new MoveStatementTestCase("tableMap statement move to head", new DfpropMoveSchemaPolicyStatementBody("tableMap", 2, 0),
+                        Arrays.asList(beforeTableStates.get(2), beforeTableStates.get(0), beforeTableStates.get(1))),
+                new MoveStatementTestCase("tableMap statement move to same", new DfpropMoveSchemaPolicyStatementBody("tableMap", 2, 2),
+                        Arrays.asList(beforeTableStates.get(0), beforeTableStates.get(1), beforeTableStates.get(2))),
+                new MoveStatementTestCase("tableMap statement move to tail", new DfpropMoveSchemaPolicyStatementBody("tableMap", 0, 2),
+                        Arrays.asList(beforeTableStates.get(1), beforeTableStates.get(2), beforeTableStates.get(0))),
+                new MoveStatementTestCase("tableMap statement fromIndex is invalid",
                         new DfpropMoveSchemaPolicyStatementBody("tableMap", -1, 2),
                         Arrays.asList(beforeTableStates.get(0), beforeTableStates.get(1), beforeTableStates.get(2)),
-                        ValidationErrorException.class
-                ),
-                new MoveStatementTestCase(
-                        "tableMap statement toIndex is invalid",
+                        ValidationErrorException.class),
+                new MoveStatementTestCase("tableMap statement toIndex is invalid",
                         new DfpropMoveSchemaPolicyStatementBody("tableMap", 0, -1),
                         Arrays.asList(beforeTableStates.get(0), beforeTableStates.get(1), beforeTableStates.get(2)),
-                        ValidationErrorException.class
-                ),
-                new MoveStatementTestCase(
-                        "tableMap statement out of index",
-                        new DfpropMoveSchemaPolicyStatementBody("tableMap", 0, 100),
+                        ValidationErrorException.class),
+                new MoveStatementTestCase("tableMap statement out of index", new DfpropMoveSchemaPolicyStatementBody("tableMap", 0, 100),
                         Arrays.asList(beforeColumnStates.get(0), beforeColumnStates.get(1), beforeColumnStates.get(2)),
-                        SchemaPolicyStatementOutOfIndexException.class
-                ),
-                new MoveStatementTestCase(
-                        "columnMap statement move to head",
-                        new DfpropMoveSchemaPolicyStatementBody("columnMap", 2, 0),
-                        Arrays.asList(beforeColumnStates.get(2), beforeColumnStates.get(0), beforeColumnStates.get(1))
-                ),
-                new MoveStatementTestCase(
-                        "columnMap statement move to same",
-                        new DfpropMoveSchemaPolicyStatementBody("columnMap", 2, 2),
-                        Arrays.asList(beforeColumnStates.get(0), beforeColumnStates.get(1), beforeColumnStates.get(2))
-                ),
-                new MoveStatementTestCase(
-                        "columnMap statement move to tail",
-                        new DfpropMoveSchemaPolicyStatementBody("columnMap", 0, 2),
-                        Arrays.asList(beforeColumnStates.get(1), beforeColumnStates.get(2), beforeColumnStates.get(0))
-                ),
-                new MoveStatementTestCase(
-                        "columnMap statement fromIndex is invalid",
+                        SchemaPolicyStatementOutOfIndexException.class),
+                new MoveStatementTestCase("columnMap statement move to head", new DfpropMoveSchemaPolicyStatementBody("columnMap", 2, 0),
+                        Arrays.asList(beforeColumnStates.get(2), beforeColumnStates.get(0), beforeColumnStates.get(1))),
+                new MoveStatementTestCase("columnMap statement move to same", new DfpropMoveSchemaPolicyStatementBody("columnMap", 2, 2),
+                        Arrays.asList(beforeColumnStates.get(0), beforeColumnStates.get(1), beforeColumnStates.get(2))),
+                new MoveStatementTestCase("columnMap statement move to tail", new DfpropMoveSchemaPolicyStatementBody("columnMap", 0, 2),
+                        Arrays.asList(beforeColumnStates.get(1), beforeColumnStates.get(2), beforeColumnStates.get(0))),
+                new MoveStatementTestCase("columnMap statement fromIndex is invalid",
                         new DfpropMoveSchemaPolicyStatementBody("columnMap", -1, 2),
                         Arrays.asList(beforeColumnStates.get(0), beforeColumnStates.get(1), beforeColumnStates.get(2)),
-                        ValidationErrorException.class
-                ),
-                new MoveStatementTestCase(
-                        "columnMap statement toIndex is invalid",
+                        ValidationErrorException.class),
+                new MoveStatementTestCase("columnMap statement toIndex is invalid",
                         new DfpropMoveSchemaPolicyStatementBody("columnMap", 0, -1),
                         Arrays.asList(beforeColumnStates.get(0), beforeColumnStates.get(1), beforeColumnStates.get(2)),
-                        ValidationErrorException.class
-                ),
-                new MoveStatementTestCase(
-                        "columnMap statement out of index",
-                        new DfpropMoveSchemaPolicyStatementBody("columnMap", 0, 100),
+                        ValidationErrorException.class),
+                new MoveStatementTestCase("columnMap statement out of index", new DfpropMoveSchemaPolicyStatementBody("columnMap", 0, 100),
                         Arrays.asList(beforeColumnStates.get(0), beforeColumnStates.get(1), beforeColumnStates.get(2)),
-                        SchemaPolicyStatementOutOfIndexException.class
-                )
-        ).forEach(testCase -> {
-            if (Objects.isNull(testCase.expectedException)) {
-                // ## Act ##
-                action.move(TEST_CLIENT_PROJECT, testCase.input);
+                        SchemaPolicyStatementOutOfIndexException.class))
+                .forEach(testCase -> {
+                    if (Objects.isNull(testCase.expectedException)) {
+                        // ## Act ##
+                        action.move(TEST_CLIENT_PROJECT, testCase.input);
 
-                // ## Assert ##
-                List<String> actual = findStatementsOf(testCase.input.mapType);
-                assertEquals(testCase.name, testCase.expected, actual);
+                        // ## Assert ##
+                        List<String> actual = findStatementsOf(testCase.input.mapType);
+                        assertEquals(testCase.name, testCase.expected, actual);
 
-                // teardown by each
-                prepareSchemaPolicyMap(dfpropPath);
-            } else {
-                // ## Act & Assert ##
-                assertException(testCase.expectedException, () -> {
-                    action.move(TEST_CLIENT_PROJECT, testCase.input);
+                        // teardown by each
+                        prepareSchemaPolicyMap(dfpropPath);
+                    } else {
+                        // ## Act & Assert ##
+                        assertException(testCase.expectedException, () -> {
+                            action.move(TEST_CLIENT_PROJECT, testCase.input);
+                        });
+                    }
                 });
-            }
-        });
     }
 
     // ===================================================================================
@@ -284,12 +252,15 @@ public class DfpropSchemapolicyStatementActionTest extends UnitIntroTestCase {
         DfpropMoveSchemaPolicyStatementBody input;
         List<String> expected;
         Class<? extends Exception> expectedException;
-        public <T extends Exception> MoveStatementTestCase(String name, DfpropMoveSchemaPolicyStatementBody input, List<String> expected, Class<T> expectedException) {
+
+        public <T extends Exception> MoveStatementTestCase(String name, DfpropMoveSchemaPolicyStatementBody input, List<String> expected,
+                Class<T> expectedException) {
             this.name = name;
             this.input = input;
             this.expected = expected;
             this.expectedException = expectedException;
         }
+
         public MoveStatementTestCase(String name, DfpropMoveSchemaPolicyStatementBody input, List<String> expected) {
             this(name, input, expected, null);
         }


### PR DESCRIPTION
## 概要

DfpropSchemaPolicyResult.javaにバリデーションアノテーションを追加し、生成されるTypeScript型のoptional(?)を解消しました。

## 変更内容

1. **VSCode設定追加**
   - Java用のEclipseフォーマッタを設定

2. **バリデーションアノテーション追加**
   - @Required, @NotNull, @Validアノテーションを追加
   - TypeScript型生成時にoptionalが付かないように修正

3. **テストコード追加**
   - DfpropSchemapolicyActionTest.javaを追加
   - アノテーション追加によりレスポンスが壊れないことを確認

4. **FreeGenによる型再生成**
   - swagger.jsonおよびTypeScript型を再生成

## 関連issue

Closes #439