### PR TITLE
#439 DfpropSchemaPolicyResultにバリデーションアノテーションを追加

### DIFF
--- a/frontend/src/static/app/api/intro/dfprop/schemapolicy/DfpropSchemapolicyResult.ts
+++ b/frontend/src/static/app/api/intro/dfprop/schemapolicy/DfpropSchemapolicyResult.ts
@@ -19,14 +19,14 @@
  * @author FreeGen
  */
 type DfpropSchemapolicyResult = {
-  /** (NullAllowed) */
-  wholeMap?: DfpropSchemapolicyResult_WholeMapPart
+  /** (Required) */
+  wholeMap: DfpropSchemapolicyResult_WholeMapPart
 
-  /** (NullAllowed) */
-  tableMap?: DfpropSchemapolicyResult_TableMapPart
+  /** (Required) */
+  tableMap: DfpropSchemapolicyResult_TableMapPart
 
-  /** (NullAllowed) */
-  columnMap?: DfpropSchemapolicyResult_ColumnMapPart
+  /** (Required) */
+  columnMap: DfpropSchemapolicyResult_ColumnMapPart
 }
 
 /**
@@ -34,8 +34,8 @@ type DfpropSchemapolicyResult = {
  * @author FreeGen
  */
 type DfpropSchemapolicyResult_WholeMapPart = {
-  /** (NullAllowed) */
-  themeList?: Array<DfpropSchemapolicyResult_ThemePart>
+  /** (NotNull) */
+  themeList: Array<DfpropSchemapolicyResult_ThemePart>
 }
 
 /**
@@ -43,17 +43,17 @@ type DfpropSchemapolicyResult_WholeMapPart = {
  * @author FreeGen
  */
 type DfpropSchemapolicyResult_ThemePart = {
-  /** (NullAllowed) */
-  name?: string
+  /** (Required) */
+  name: string
 
-  /** (NullAllowed) */
-  description?: string
+  /** (Required) */
+  description: string
 
-  /** (NullAllowed) */
-  typeCode?: string
+  /** (Required) */
+  typeCode: string
 
-  /** (NullAllowed) */
-  isActive?: boolean
+  /** (Required) */
+  isActive: boolean
 }
 
 /**
@@ -61,11 +61,11 @@ type DfpropSchemapolicyResult_ThemePart = {
  * @author FreeGen
  */
 type DfpropSchemapolicyResult_TableMapPart = {
-  /** (NullAllowed) */
-  themeList?: Array<DfpropSchemapolicyResult_ThemePart>
+  /** (NotNull) */
+  themeList: Array<DfpropSchemapolicyResult_ThemePart>
 
-  /** (NullAllowed) */
-  statementList?: Array<string>
+  /** (NotNull) */
+  statementList: Array<string>
 }
 
 /**
@@ -73,9 +73,9 @@ type DfpropSchemapolicyResult_TableMapPart = {
  * @author FreeGen
  */
 type DfpropSchemapolicyResult_ColumnMapPart = {
-  /** (NullAllowed) */
-  themeList?: Array<DfpropSchemapolicyResult_ThemePart>
+  /** (NotNull) */
+  themeList: Array<DfpropSchemapolicyResult_ThemePart>
 
-  /** (NullAllowed) */
-  statementList?: Array<string>
+  /** (NotNull) */
+  statementList: Array<string>
 }

--- a/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/DfpropSchemaPolicyResult.java
+++ b/src/main/java/org/dbflute/intro/app/web/dfprop/schemapolicy/DfpropSchemaPolicyResult.java
@@ -18,10 +18,14 @@ package org.dbflute.intro.app.web.dfprop.schemapolicy;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
 import org.dbflute.intro.app.model.client.document.SchemaPolicyColumnMap;
 import org.dbflute.intro.app.model.client.document.SchemaPolicyMap;
 import org.dbflute.intro.app.model.client.document.SchemaPolicyTableMap;
 import org.dbflute.intro.app.model.client.document.SchemaPolicyWholeMap;
+import org.lastaflute.web.validation.Required;
 
 /**
  * @author hakiba
@@ -29,7 +33,10 @@ import org.dbflute.intro.app.model.client.document.SchemaPolicyWholeMap;
 public class DfpropSchemaPolicyResult {
 
     public static class WholeMap {
-        List<Theme> themeList;
+
+        @Required
+        @Valid
+        public List<Theme> themeList;
 
         public WholeMap(SchemaPolicyWholeMap wholeMap) {
             this.themeList = wholeMap.themeList.stream().map(theme -> new Theme(theme)).collect(Collectors.toList());
@@ -37,8 +44,13 @@ public class DfpropSchemaPolicyResult {
     }
 
     public static class TableMap {
-        List<Theme> themeList;
-        List<String> statementList;
+
+        @Required
+        @Valid
+        public List<Theme> themeList;
+
+        @NotNull
+        public List<String> statementList;
 
         public TableMap(SchemaPolicyTableMap tableMap) {
             this.themeList = tableMap.themeList.stream().map(theme -> new Theme(theme)).collect(Collectors.toList());
@@ -47,8 +59,13 @@ public class DfpropSchemaPolicyResult {
     }
 
     public static class ColumnMap {
-        List<Theme> themeList;
-        List<String> statementList;
+
+        @Required
+        @Valid
+        public List<Theme> themeList;
+
+        @NotNull
+        public List<String> statementList;
 
         public ColumnMap(SchemaPolicyColumnMap columnMap) {
             this.themeList = columnMap.themeList.stream().map(theme -> new Theme(theme)).collect(Collectors.toList());
@@ -57,10 +74,18 @@ public class DfpropSchemaPolicyResult {
     }
 
     public static class Theme {
-        String name;
-        String description;
-        String typeCode;
-        Boolean isActive;
+
+        @Required
+        public String name;
+
+        @Required
+        public String description;
+
+        @Required
+        public String typeCode;
+
+        @Required
+        public Boolean isActive;
 
         public Theme(SchemaPolicyWholeMap.Theme theme) {
             this.name = theme.type.name();
@@ -84,8 +109,16 @@ public class DfpropSchemaPolicyResult {
         }
     }
 
+    @Required
+    @Valid
     public WholeMap wholeMap;
+
+    @Required
+    @Valid
     public TableMap tableMap;
+
+    @Required
+    @Valid
     public ColumnMap columnMap;
 
     public DfpropSchemaPolicyResult(SchemaPolicyMap schemaPolicyMap) {

--- a/src/main/resources/remoteapi/schema/remoteapi_schema_intro_swagger.json
+++ b/src/main/resources/remoteapi/schema/remoteapi_schema_intro_swagger.json
@@ -2027,6 +2027,12 @@
     },
     "org.dbflute.intro.app.web.dfprop.schemapolicy.DfpropSchemaPolicyResult$Theme": {
       "type": "object",
+      "required": [
+        "name",
+        "description",
+        "typeCode",
+        "isActive"
+      ],
       "properties": {
         "name": {
           "type": "string"
@@ -2044,6 +2050,9 @@
     },
     "org.dbflute.intro.app.web.dfprop.schemapolicy.DfpropSchemaPolicyResult$WholeMap": {
       "type": "object",
+      "required": [
+        "themeList"
+      ],
       "properties": {
         "themeList": {
           "type": "array",
@@ -2055,6 +2064,10 @@
     },
     "org.dbflute.intro.app.web.dfprop.schemapolicy.DfpropSchemaPolicyResult$TableMap": {
       "type": "object",
+      "required": [
+        "themeList",
+        "statementList"
+      ],
       "properties": {
         "themeList": {
           "type": "array",
@@ -2072,6 +2085,10 @@
     },
     "org.dbflute.intro.app.web.dfprop.schemapolicy.DfpropSchemaPolicyResult$ColumnMap": {
       "type": "object",
+      "required": [
+        "themeList",
+        "statementList"
+      ],
       "properties": {
         "themeList": {
           "type": "array",
@@ -2089,6 +2106,11 @@
     },
     "org.dbflute.intro.app.web.dfprop.schemapolicy.DfpropSchemaPolicyResult": {
       "type": "object",
+      "required": [
+        "wholeMap",
+        "tableMap",
+        "columnMap"
+      ],
       "properties": {
         "wholeMap": {
           "$ref": "#/definitions/org.dbflute.intro.app.web.dfprop.schemapolicy.DfpropSchemaPolicyResult%24WholeMap"

--- a/src/test/java/org/dbflute/intro/app/web/dfprop/schemapolicy/DfpropSchemapolicyActionTest.java
+++ b/src/test/java/org/dbflute/intro/app/web/dfprop/schemapolicy/DfpropSchemapolicyActionTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2014-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.dbflute.intro.app.web.dfprop.schemapolicy;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.dbflute.intro.bizfw.tellfailure.DfpropFileNotFoundException;
+import org.dbflute.intro.unit.UnitIntroTestCase;
+
+/**
+ * @author cabos
+ */
+public class DfpropSchemapolicyActionTest extends UnitIntroTestCase {
+
+    // ===================================================================================
+    //                                                                                Test
+    //                                                                                ====
+    /**
+     * themeListとstatementListの両方に設定がある場合、エラーなくレスポンスが返ること。
+     */
+    public void test_index_hasSetting() throws Exception {
+        // ## Arrange ##
+        DfpropSchemapolicyAction action = new DfpropSchemapolicyAction();
+        inject(action);
+        prepareSchemaPolicyMap("dfprop/schemaPolicyMap.dfprop");
+
+        // ## Act ##
+        action.index(TEST_CLIENT_PROJECT);
+
+        // ## Assert ##
+        // 例外が発生しないこと
+    }
+
+    /**
+     * schemaPolicyMap.dfpropの設定が空の場合、エラーなくレスポンスが返ること。
+     */
+    public void test_index_emptySettings() throws Exception {
+        // ## Arrange ##
+        DfpropSchemapolicyAction action = new DfpropSchemapolicyAction();
+        inject(action);
+        prepareSchemaPolicyMap("dfprop/noSetting_schemaPolicyMap.dfprop");
+
+        // ## Act ##
+        action.index(TEST_CLIENT_PROJECT);
+
+        // ## Assert ##
+        // 例外が発生しないこと
+    }
+
+    /**
+     * schemaPolicyMap.dfpropが存在しない場合、DfpropFileNotFoundExceptionが発生すること。
+     */
+    public void test_index_fileNotExists() throws Exception {
+        // ## Arrange ##
+        DfpropSchemapolicyAction action = new DfpropSchemapolicyAction();
+        inject(action);
+        File schemaPolicyMapFile = findTestClientFile("dfprop/schemaPolicyMap.dfprop");
+        schemaPolicyMapFile.delete();
+
+        // ## Act & Assert ##
+        assertException(DfpropFileNotFoundException.class, () -> action.index(TEST_CLIENT_PROJECT));
+    }
+
+    // ===================================================================================
+    //                                                                        Assist Logic
+    //                                                                        ============
+    private void prepareSchemaPolicyMap(String filePath) {
+        File srcFile = findTestResourceFile(filePath);
+        File destFile = findTestClientFile("dfprop/schemaPolicyMap.dfprop");
+        try {
+            FileUtils.copyFile(srcFile, destFile);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to copy file: src=" + srcFile + ", dest=" + destFile, e);
+        }
+    }
+}


### PR DESCRIPTION
## 概要

DfpropSchemaPolicyResult.javaにバリデーションアノテーションを追加し、生成されるTypeScript型のoptional(?)を解消しました。

## 変更内容

1. **バリデーションアノテーション追加**
   - @Required, @NotNull, @Validアノテーションを追加
   - TypeScript型生成時にoptionalが付かないように修正

2. **テストコード追加**
   - DfpropSchemapolicyActionTest.javaを追加
   - アノテーション追加によりレスポンスが壊れないことを確認

3. **FreeGenによる型再生成**
   - swagger.jsonおよびTypeScript型を再生成

## 関連issue

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)