### PR TITLE
Feature/#533 taskexecute modal organization

### DIFF
--- a/frontend/src/static/app/pages/client/latest-result.ts
+++ b/frontend/src/static/app/pages/client/latest-result.ts
@@ -1,12 +1,28 @@
 import { IntroRiotComponent, withIntroTypes } from '../../app-component-types'
 import Raw from '../../components/common/raw.riot'
 
+// > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >
+// ^                                                                                     v
+// ^                                                                                     v
+// ^                                                                                     v
+// < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < <
+
 interface Props {
+  /** 現在対象としているDBFluteクライアントをプロジェクト名 e.g. maihamadb */
   projectName: string
-  task: string
+
+  /** その直近のDBFluteタスクの名前 */
+  task: string // #thinking jflute unusedに見えるが、いつか使うかもで念のため受けってる？ (2026/04/10)
+
+  /** その直近のDBFluteタスク実行が "成功" で終了したか？ */
   success: boolean
+
+  /** 表示領域のヘッダー (タイトル表示) を表示するかどうか？ */
   showHeader: boolean
-  headerTitle?: string
+
+  /** 表示領域のヘッダーに表示するタイトル文字列 */
+  headerTitle?: string // #thinking jflute ないかも項目だけど、.riotでそのまま使ってるけどOK？ (2026/04/10)
+
   resultTitle: string
   resultMessage?: string
   content?: string
@@ -19,10 +35,22 @@ interface State {
   showContent: boolean
 }
 
+// > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >
+// ^                                                                                     v
+// ^                                                                                     v
+// ^                                                                                     v
+// < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < <
+
 interface LatestResult extends IntroRiotComponent<Props, State> {
   onMounted(): void
   toggleLatestResult(): void
 }
+
+// > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >
+// ^                                                                                     v
+// ^                                                                                     v
+// ^                                                                                     v
+// < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < <
 
 export default withIntroTypes<LatestResult>({
   components: {

--- a/frontend/src/static/app/pages/client/latest-result.ts
+++ b/frontend/src/static/app/pages/client/latest-result.ts
@@ -20,18 +20,34 @@ interface Props {
   /** 表示領域のヘッダー (タイトル表示) を表示するかどうか？ */
   showHeader: boolean
 
+  // #thinking jflute 使ってる人がいないような？ (2026/04/25)
   /** 表示領域のヘッダーに表示するタイトル文字列 */
-  headerTitle?: string // #thinking jflute ないかも項目だけど、.riotでそのまま使ってるけどOK？ (2026/04/10)
+  headerTitle?: string
 
+  /** DBFluteタスク実行結果を表現するタイトル e.g. Execution Result: Success */
   resultTitle: string
+
+  // #thinking jflute 使ってる人がいないような？あったらあったで良いと思うところだが... (2026/04/25)
+  /** 実行結果タイトルの下に表示される結果メッセージ (エラーに対する短文の案内とか!?) */
   resultMessage?: string
+
+  /** 実行結果の具体的な内容いっぱい (エラーログそのまんまなど) e.g. "[df-replace-schema] /* * ..." */
   content?: string
+
+  // #thinking jflute これまた使ってる人がいないような？ (2026/04/25)
+  /** エラー時案内のリンクのタイトル (一個前の画面に戻るとか、ドキュメントページを表示とか) */
   linkTitle?: string
+
+  /** エラー時案内のリンクの押下イベント (一個前の画面に戻るとか、ドキュメントページを表示とか) */
   onClickLink?: () => void
 }
 
 interface State {
+  // #thinking jflute でも、利用側でif書いて制御してるので、この制御使われてるだろうか？ (2026/04/25)
+  /** このlatest-result自体の表示領域を表示するかどうか？ */
   loaded: boolean
+
+  /** 大量メッセージのcontent領域を表示するかどうか？ (toggleでhide/show制御するためのもの) */
   showContent: boolean
 }
 
@@ -42,7 +58,20 @@ interface State {
 // < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < <
 
 interface LatestResult extends IntroRiotComponent<Props, State> {
+  // ===================================================================================
+  //                                                                           Lifecycle
+  //                                                                           =========
+  /**
+   * マウント完了時の処理。
+   */
   onMounted(): void
+
+  // ===================================================================================
+  //                                                                       Event Handler
+  //                                                                       =============
+  /**
+   * 大量メッセージのcontent領域を表示on/offを反転させる。
+   */
   toggleLatestResult(): void
 }
 

--- a/frontend/src/static/app/pages/client/task-execute-modal.ts
+++ b/frontend/src/static/app/pages/client/task-execute-modal.ts
@@ -1,7 +1,8 @@
 import { IntroRiotComponent, withIntroTypes } from '../../app-component-types'
 
-// #thinking jflute None はどういう状態を想定しているものなのか？モーダルを出さない便宜上のデフォルトの状態？ (2026/03/20)
+// done jflute None はどういう状態を想定しているものなのか？モーダルを出さない便宜上のデフォルトの状態？ (2026/03/20)
 // task-execute-modalタグは常に評価されるから、最初の画面描画時などタスク実行してない時はNoneで何も起きないようにしている？
+// → という解釈で良いと思う (2026/04/10)
 /**
  * DBFluteタスク実行ステータス。
  */

--- a/frontend/src/static/app/pages/client/task-execute-modal.ts
+++ b/frontend/src/static/app/pages/client/task-execute-modal.ts
@@ -1,13 +1,33 @@
 import { IntroRiotComponent, withIntroTypes } from '../../app-component-types'
 
+// #thinking jflute None はどういう状態を想定しているものなのか？モーダルを出さない便宜上のデフォルトの状態？ (2026/03/20)
+// task-execute-modalタグは常に評価されるから、最初の画面描画時などタスク実行してない時はNoneで何も起きないようにしている？
+/**
+ * DBFluteタスク実行ステータス。
+ */
 export type TaskExecuteStatus = 'None' | 'Executing' | 'Completed'
 
+// > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >
+// ^                                                                                     v
+// ^                                                                                     v
+// ^                                                                                     v
+// < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < <
+
+/**
+ * タスク実行結果のメッセージなどタグ引数で受け取る。
+ */
 interface Props {
+  /** モーダルに表示するIntroユーザー向けメッセージ。 */
   message: string
+
+  /** DBFluteタスク実行ステータス。 */
   status: TaskExecuteStatus
+
+  /** モーダルを閉じた時の処理のフック。呼び出し側が好きな処理を実行できるように。 (EmptyAllowed: 好きな処理なければ) */
   onModalHide?: () => void
 }
 
+// #thinking jflute onBeforeUpdate()にてstatusをPropsから受け取ってchangeさせてるけど、Propsのstatusを全部直接使うじゃダメなのかな？ (2026/03/20)
 interface State {
   status: TaskExecuteStatus
 }
@@ -37,12 +57,24 @@ const EXECUTING_MODAL: SuModal = {
   buttons: [],
 }
 
+// > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >
+// ^                                                                                     v
+// ^                                                                                     v
+// ^                                                                                     v
+// < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < <
+
 interface TaskExecuteModal extends IntroRiotComponent<Props, State> {
   onBeforeUpdate(): void
   show(): boolean
   modal(): SuModal | undefined
   onHide(): void
 }
+
+// > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >
+// ^                                                                                     v
+// ^                                                                                     v
+// ^                                                                                     v
+// < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < <
 
 export default withIntroTypes<TaskExecuteModal>({
   state: {

--- a/frontend/src/static/app/pages/client/task-execute-modal.ts
+++ b/frontend/src/static/app/pages/client/task-execute-modal.ts
@@ -20,28 +20,43 @@ interface Props {
   /** モーダルに表示するIntroユーザー向けメッセージ。 */
   message: string
 
-  /** DBFluteタスク実行ステータス。 */
+  /** DBFluteタスク実行ステータス。実際に実行した結果だったり、画面再初期化のためにNoneだったり。 */
   status: TaskExecuteStatus
 
   /** モーダルを閉じた時の処理のフック。呼び出し側が好きな処理を実行できるように。 (EmptyAllowed: 好きな処理なければ) */
   onModalHide?: () => void
 }
 
-// #thinking jflute onBeforeUpdate()にてstatusをPropsから受け取ってchangeさせてるけど、Propsのstatusを全部直接使うじゃダメなのかな？ (2026/03/20)
 interface State {
+  /**
+   * DBFluteタスク実行ステータス。
+   * コンポーネント更新前に Props の status の値を引き継ぐ。
+   * モーダル表示中は実際に実行した結果で、初期状態や隠れているときはNoneになる。
+   */
   status: TaskExecuteStatus
 }
 
+/**
+ * モーダル上のボタンオブジェクト
+ */
 type SuModalButton = {
+  /** ボタン表示名 */
   text: string
+  /** デフォルトでフォーカスが当たってるどうか？ (Enterですぐに押せるかどうか？でいいのかな？) */
   default: boolean
 }
 
+/**
+ * モーダル自体のオブジェクト
+ */
 type SuModal = {
+  /** モーダルダイアログをUIで閉じることができるかどうか？ */
   closable: boolean
+  /** モーダル上のボタンオブジェクトたち (EmptyAllowed) */
   buttons: SuModalButton[]
 }
 
+/** 完了を示すモーダルダイアログ。su-modalに引き渡すオブジェクト。 */
 const COMPLETED_MODAL: SuModal = {
   closable: true,
   buttons: [
@@ -52,6 +67,7 @@ const COMPLETED_MODAL: SuModal = {
   ],
 }
 
+/** 実行中を示すモーダルダイアログ。su-modalに引き渡すオブジェクト。 */
 const EXECUTING_MODAL: SuModal = {
   closable: false,
   buttons: [],
@@ -64,9 +80,29 @@ const EXECUTING_MODAL: SuModal = {
 // < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < <
 
 interface TaskExecuteModal extends IntroRiotComponent<Props, State> {
-  onBeforeUpdate(): void
+  // ===================================================================================
+  //                                                                           Lifecycle
+  //                                                                           =========
+  onBeforeUpdate(): void // コンポーネントの更新前に呼ばれる
+
+  // ===================================================================================
+  //                                                                       Event Handler
+  //                                                                       =============
+  /**
+   * su-modal の show 相当。
+   * @return モーダルを表示するかどうか？
+   */
   show(): boolean
+
+  /**
+   * su-modal の modal 相当。
+   * @return 表示するモーダルオブジェクト (非表示 if undefined)
+   */
   modal(): SuModal | undefined
+
+  /**
+   * su-modal の onhide 相当。モーダルが隠れた時の処理。
+   */
   onHide(): void
 }
 
@@ -80,9 +116,17 @@ export default withIntroTypes<TaskExecuteModal>({
   state: {
     status: 'None',
   },
+
+  // ===================================================================================
+  //                                                                           Lifecycle
+  //                                                                           =========
   onBeforeUpdate() {
     this.state.status = this.props.status
   },
+
+  // ===================================================================================
+  //                                                                       Event Handler
+  //                                                                       =============
   show(): boolean {
     return this.state.status !== 'None'
   },


### PR DESCRIPTION
# 概要
[Riot7] 実装ポリシーのさらなる横断修正
https://github.com/dbflute/dbflute-intro/issues/533
の一環。

主に以下の二つ:
o task-execute-modal
o latest-result
