### PR TITLE
Fix Riot7 database info route tag

### DIFF
--- a/frontend/src/static/app/pages/client/client-router.riot
+++ b/frontend/src/static/app/pages/client/client-router.riot
@@ -16,7 +16,7 @@
     <ex-schema-policy-check></ex-schema-policy-check>
   </route>
   <route path={ state.routes.settingsDatabaseInfo.path }>
-    <st-database-info project-name={ props.projectName }></st-database-info>
+    <database-info project-name={ props.projectName }></database-info>
   </route>
   <route path={ state.routes.filesLogs.path }>
     <logs project-name={ props.projectName }></logs>


### PR DESCRIPTION
## 概要
Riot 7 側で `Database Info` 画面が表示されない問題を修正しました。

## 変更内容
- `frontend/src/static/app/pages/client/client-router.riot` を修正
- ルーティング先で使用していた `<st-database-info>` を `<database-info>` に変更

## 原因
`Database Info` のルート自体とバックエンド API は正しく存在していましたが、
`client-router.riot` で使用しているタグ名が、`components` に登録しているコンポーネント名と一致していませんでした。

そのため、`/#client/{projectName}/settings/database-info` に遷移しても
対象コンポーネントが正しくマウントされず、画面が空表示になっていました。

## 修正後の挙動
- Riot 7 で `Database Info` 画面が正しくマウントされるようになります
- `/#client/trohamadb/settings/database-info` で画面表示できることを想定しています

## 確認内容
- `Database Info` 画面が表示されること
