### PR TITLE
Fix/#558 task execute modal error state

### DIFF
--- a/frontend/src/static/app/pages/client/alter-check/alter-check.ts
+++ b/frontend/src/static/app/pages/client/alter-check/alter-check.ts
@@ -159,7 +159,7 @@ export default withIntroTypes<AlterCheck>({
           this.updateContents({ executeStatus: 'Completed', executeResultMessage })
         })
         .catch(() => {
-          this.update({ executeStatus: 'Error', executeResultMessage: 'Unexpected error occurred.' })
+          this.update({ executeStatus: 'Error', executeResultMessage: 'Could not complete the task.\nPlease try again.' })
         })
     })
   },

--- a/frontend/src/static/app/pages/client/alter-check/alter-check.ts
+++ b/frontend/src/static/app/pages/client/alter-check/alter-check.ts
@@ -159,8 +159,7 @@ export default withIntroTypes<AlterCheck>({
           this.updateContents({ executeStatus: 'Completed', executeResultMessage })
         })
         .catch(() => {
-          // APIリクエストに失敗した際の情報も反映するため更新（一緒に実行モーダルは閉じる）
-          this.updateContents({ executeStatus: 'None' })
+          this.update({ executeStatus: 'Error', executeResultMessage: 'Unexpected error occurred.' })
         })
     })
   },

--- a/frontend/src/static/app/pages/client/alter-check/alter-check.ts
+++ b/frontend/src/static/app/pages/client/alter-check/alter-check.ts
@@ -159,7 +159,7 @@ export default withIntroTypes<AlterCheck>({
           this.updateContents({ executeStatus: 'Completed', executeResultMessage })
         })
         .catch(() => {
-          this.update({ executeStatus: 'Error', executeResultMessage: 'Could not complete the task.\nPlease try again.' })
+          this.update({ executeStatus: 'Error', executeResultMessage: 'Could not complete the task. Please try again.' })
         })
     })
   },

--- a/frontend/src/static/app/pages/client/documents/documents.ts
+++ b/frontend/src/static/app/pages/client/documents/documents.ts
@@ -140,7 +140,7 @@ export default withIntroTypes<Document>({
         await this.updateContents({ executeStatus: 'Completed', executeResultMessage })
       })
       .catch(async () => {
-        this.update({ executeStatus: 'Error', executeResultMessage: 'Unexpected error occurred.' })
+        this.update({ executeStatus: 'Error', executeResultMessage: 'Could not complete the task.\nPlease try again.' })
       })
   },
 

--- a/frontend/src/static/app/pages/client/documents/documents.ts
+++ b/frontend/src/static/app/pages/client/documents/documents.ts
@@ -140,7 +140,7 @@ export default withIntroTypes<Document>({
         await this.updateContents({ executeStatus: 'Completed', executeResultMessage })
       })
       .catch(async () => {
-        this.update({ executeStatus: 'Error', executeResultMessage: 'Could not complete the task.\nPlease try again.' })
+        this.update({ executeStatus: 'Error', executeResultMessage: 'Could not complete the task. Please try again.' })
       })
   },
 

--- a/frontend/src/static/app/pages/client/documents/documents.ts
+++ b/frontend/src/static/app/pages/client/documents/documents.ts
@@ -132,7 +132,7 @@ export default withIntroTypes<Document>({
     if (this.state.executeStatus !== 'None') {
       return
     }
-    await this.updateContents({ executeStatus: 'Executing', executeResultMessage: 'Generating...' })
+    this.update({ executeStatus: 'Executing', executeResultMessage: 'Generating...' })
     await api
       .executeTask(this.props.projectName, 'doc')
       .then(async (data) => {
@@ -140,8 +140,7 @@ export default withIntroTypes<Document>({
         await this.updateContents({ executeStatus: 'Completed', executeResultMessage })
       })
       .catch(async () => {
-        // APIリクエストに失敗した際の情報も反映するため更新（一緒に実行モーダルは閉じる）
-        await this.updateContents({ executeStatus: 'None' })
+        this.update({ executeStatus: 'Error', executeResultMessage: 'Unexpected error occurred.' })
       })
   },
 

--- a/frontend/src/static/app/pages/client/replace-schema/replace-schema.ts
+++ b/frontend/src/static/app/pages/client/replace-schema/replace-schema.ts
@@ -221,9 +221,8 @@ export default withIntroTypes<ReplaceSchema>({
     try {
       const data = await api.executeTask(projectName, 'replaceSchema')
       state = { executeStatus: 'Completed' as TaskExecuteStatus, executeResultMessage: data.success ? 'Success' : 'Failure' }
-    } catch (e) {
-      console.error('Failed ReplaceSchema:', e)
-      state = { executeStatus: 'None' as TaskExecuteStatus }
+    } catch {
+      state = { executeStatus: 'Error' as TaskExecuteStatus, executeResultMessage: 'Unexpected error occurred.' }
     }
 
     this.update(state)

--- a/frontend/src/static/app/pages/client/replace-schema/replace-schema.ts
+++ b/frontend/src/static/app/pages/client/replace-schema/replace-schema.ts
@@ -222,7 +222,7 @@ export default withIntroTypes<ReplaceSchema>({
       const data = await api.executeTask(projectName, 'replaceSchema')
       state = { executeStatus: 'Completed' as TaskExecuteStatus, executeResultMessage: data.success ? 'Success' : 'Failure' }
     } catch {
-      state = { executeStatus: 'Error' as TaskExecuteStatus, executeResultMessage: 'Unexpected error occurred.' }
+      state = { executeStatus: 'Error' as TaskExecuteStatus, executeResultMessage: 'Could not complete the task.\nPlease try again.' }
     }
 
     this.update(state)

--- a/frontend/src/static/app/pages/client/replace-schema/replace-schema.ts
+++ b/frontend/src/static/app/pages/client/replace-schema/replace-schema.ts
@@ -222,7 +222,7 @@ export default withIntroTypes<ReplaceSchema>({
       const data = await api.executeTask(projectName, 'replaceSchema')
       state = { executeStatus: 'Completed' as TaskExecuteStatus, executeResultMessage: data.success ? 'Success' : 'Failure' }
     } catch {
-      state = { executeStatus: 'Error' as TaskExecuteStatus, executeResultMessage: 'Could not complete the task.\nPlease try again.' }
+      state = { executeStatus: 'Error' as TaskExecuteStatus, executeResultMessage: 'Could not complete the task. Please try again.' }
     }
 
     this.update(state)

--- a/frontend/src/static/app/pages/client/schema-sync-check/schema-sync-check.ts
+++ b/frontend/src/static/app/pages/client/schema-sync-check/schema-sync-check.ts
@@ -137,7 +137,7 @@ export default withIntroTypes<SchemaSyncCheck>({
         await this.updateContents({ executeStatus: 'Completed', executeResultMessage })
       })
       .catch(async () => {
-        this.update({ executeStatus: 'Error', executeResultMessage: 'Could not complete the task.\nPlease try again.' })
+        this.update({ executeStatus: 'Error', executeResultMessage: 'Could not complete the task. Please try again.' })
       })
   },
 

--- a/frontend/src/static/app/pages/client/schema-sync-check/schema-sync-check.ts
+++ b/frontend/src/static/app/pages/client/schema-sync-check/schema-sync-check.ts
@@ -137,7 +137,7 @@ export default withIntroTypes<SchemaSyncCheck>({
         await this.updateContents({ executeStatus: 'Completed', executeResultMessage })
       })
       .catch(async () => {
-        this.update({ executeStatus: 'Error', executeResultMessage: 'Unexpected error occurred.' })
+        this.update({ executeStatus: 'Error', executeResultMessage: 'Could not complete the task.\nPlease try again.' })
       })
   },
 

--- a/frontend/src/static/app/pages/client/schema-sync-check/schema-sync-check.ts
+++ b/frontend/src/static/app/pages/client/schema-sync-check/schema-sync-check.ts
@@ -129,7 +129,7 @@ export default withIntroTypes<SchemaSyncCheck>({
     if (this.state.executeStatus !== 'None') {
       return
     }
-    await this.updateContents({ executeStatus: 'Executing', executeResultMessage: 'Executing...' })
+    this.update({ executeStatus: 'Executing', executeResultMessage: 'Executing...' })
     await api
       .executeTask(this.props.projectName, 'schemaSyncCheck')
       .then(async (data) => {
@@ -137,8 +137,7 @@ export default withIntroTypes<SchemaSyncCheck>({
         await this.updateContents({ executeStatus: 'Completed', executeResultMessage })
       })
       .catch(async () => {
-        // APIリクエストに失敗した際の情報も反映するため更新（一緒に実行モーダルは閉じる）
-        await this.updateContents({ executeStatus: 'None' })
+        this.update({ executeStatus: 'Error', executeResultMessage: 'Unexpected error occurred.' })
       })
   },
 
@@ -167,7 +166,6 @@ export default withIntroTypes<SchemaSyncCheck>({
   async updateContents(additionalState?: Partial<State>) {
     const projectName = this.props.projectName
     const syncSchemaSetting = await api.findSchemaSyncDfprop(projectName)
-    console.log('Fetched syncSchemaSetting:', syncSchemaSetting)
     const latestResult = await api.findLatestTaskLog(projectName, 'schemaSyncCheck').then((body) => {
       if (body) {
         return {

--- a/frontend/src/static/app/pages/client/task-execute-modal.riot
+++ b/frontend/src/static/app/pages/client/task-execute-modal.riot
@@ -1,9 +1,20 @@
 <result-modal>
-  <su-modal modal="{ modal() }" show="{ show() }" onhide="{ onHide }" class="large">
+  <su-modal modal="{ modal() }" show="{ show() }" onhide="{ onHide }" class="large { errorClass() }">
     <div class="description">
       { props.message }
     </div>
   </su-modal>
+
+  <style>
+    .ui.modal.task-execute-error-tone > .content,
+    .ui.modal.task-execute-error-tone > .actions {
+      background-color: #FFEEEE;
+    }
+
+    .ui.modal.task-execute-error-tone > .content {
+      color: #AA4455;
+    }
+  </style>
 
   <script>
     import resultModal from './task-execute-modal'

--- a/frontend/src/static/app/pages/client/task-execute-modal.riot
+++ b/frontend/src/static/app/pages/client/task-execute-modal.riot
@@ -1,9 +1,39 @@
 <result-modal>
-  <su-modal modal="{ modal() }" show="{ show() }" onhide="{ onHide }" class="large">
-    <div class="description">
+  <su-modal modal="{ modal() }" show="{ show() }" onhide="{ onHide }" class="large { modalClass() }">
+    <div class="description { modalClass() ? 'message-area' : '' }">
       { props.message }
     </div>
   </su-modal>
+
+  <style>
+    .ui.modal.architrave.task-execute-error-modal > .header,
+    .ui.modal.architrave.task-execute-error-modal > .actions {
+      background-color: #ffefef;
+    }
+
+    .ui.modal.architrave.task-execute-error-modal > .header {
+      border-radius: 0 0 50px 0 / 0 0 50px 0;
+      color: #aa4455;
+    }
+
+    .ui.modal.task-execute-error-modal > .content {
+      color: rgba(0, 0, 0, 0.87);
+    }
+
+    .ui.modal.architrave.task-execute-error-modal > .actions {
+      border-radius: 50px 0 0 0 / 50px 0 0 0;
+    }
+
+    .ui.modal.task-execute-error-modal .message-area {
+      font-size: 1.2em;
+      padding-left: 0.5em;
+      white-space: pre-line;
+    }
+
+    .ui.modal.task-execute-error-modal > .actions {
+      color: #9f3a38;
+    }
+  </style>
 
   <script>
     import resultModal from './task-execute-modal'

--- a/frontend/src/static/app/pages/client/task-execute-modal.riot
+++ b/frontend/src/static/app/pages/client/task-execute-modal.riot
@@ -1,39 +1,9 @@
 <result-modal>
-  <su-modal modal="{ modal() }" show="{ show() }" onhide="{ onHide }" class="large { modalClass() }">
-    <div class="description { modalClass() ? 'message-area' : '' }">
+  <su-modal modal="{ modal() }" show="{ show() }" onhide="{ onHide }" class="large">
+    <div class="description">
       { props.message }
     </div>
   </su-modal>
-
-  <style>
-    .ui.modal.architrave.task-execute-error-modal > .header,
-    .ui.modal.architrave.task-execute-error-modal > .actions {
-      background-color: #ffefef;
-    }
-
-    .ui.modal.architrave.task-execute-error-modal > .header {
-      border-radius: 0 0 50px 0 / 0 0 50px 0;
-      color: #aa4455;
-    }
-
-    .ui.modal.task-execute-error-modal > .content {
-      color: rgba(0, 0, 0, 0.87);
-    }
-
-    .ui.modal.architrave.task-execute-error-modal > .actions {
-      border-radius: 50px 0 0 0 / 50px 0 0 0;
-    }
-
-    .ui.modal.task-execute-error-modal .message-area {
-      font-size: 1.2em;
-      padding-left: 0.5em;
-      white-space: pre-line;
-    }
-
-    .ui.modal.task-execute-error-modal > .actions {
-      color: #9f3a38;
-    }
-  </style>
 
   <script>
     import resultModal from './task-execute-modal'

--- a/frontend/src/static/app/pages/client/task-execute-modal.ts
+++ b/frontend/src/static/app/pages/client/task-execute-modal.ts
@@ -55,6 +55,8 @@ type SuModal = {
   closable: boolean
   /** モーダル上のボタンオブジェクトたち (EmptyAllowed) */
   buttons: SuModalButton[]
+  /** モーダルヘッダーに表示するタイトル。 */
+  header?: string
 }
 
 /** 完了を示すモーダルダイアログ。su-modalに引き渡すオブジェクト。 */
@@ -71,6 +73,7 @@ const COMPLETED_MODAL: SuModal = {
 /** 例外発生を示すモーダルダイアログ。su-modalに引き渡すオブジェクト。 */
 const ERROR_MODAL: SuModal = {
   closable: true,
+  header: 'Unexpected Error',
   buttons: [
     {
       text: 'CLOSE',
@@ -107,6 +110,12 @@ interface TaskExecuteModal extends IntroRiotComponent<Props, State> {
   show(): boolean
 
   /**
+   * モーダル全体の見た目に利用するclass属性値。
+   * @return 表示用のclass属性値
+   */
+  modalClass(): string
+
+  /**
    * su-modal の modal 相当。
    * @return 表示するモーダルオブジェクト (非表示 if undefined)
    */
@@ -141,6 +150,9 @@ export default withIntroTypes<TaskExecuteModal>({
   //                                                                       =============
   show(): boolean {
     return this.state.status !== 'None'
+  },
+  modalClass(): string {
+    return this.state.status === 'Error' ? 'architrave task-execute-error-modal' : ''
   },
   modal(): SuModal | undefined {
     switch (this.state.status) {

--- a/frontend/src/static/app/pages/client/task-execute-modal.ts
+++ b/frontend/src/static/app/pages/client/task-execute-modal.ts
@@ -55,8 +55,6 @@ type SuModal = {
   closable: boolean
   /** モーダル上のボタンオブジェクトたち (EmptyAllowed) */
   buttons: SuModalButton[]
-  /** モーダルヘッダーに表示するタイトル。 */
-  header?: string
 }
 
 /** 完了を示すモーダルダイアログ。su-modalに引き渡すオブジェクト。 */

--- a/frontend/src/static/app/pages/client/task-execute-modal.ts
+++ b/frontend/src/static/app/pages/client/task-execute-modal.ts
@@ -73,7 +73,6 @@ const COMPLETED_MODAL: SuModal = {
 /** 例外発生を示すモーダルダイアログ。su-modalに引き渡すオブジェクト。 */
 const ERROR_MODAL: SuModal = {
   closable: true,
-  header: 'Unexpected Error',
   buttons: [
     {
       text: 'CLOSE',
@@ -110,12 +109,6 @@ interface TaskExecuteModal extends IntroRiotComponent<Props, State> {
   show(): boolean
 
   /**
-   * モーダル全体の見た目に利用するclass属性値。
-   * @return 表示用のclass属性値
-   */
-  modalClass(): string
-
-  /**
    * su-modal の modal 相当。
    * @return 表示するモーダルオブジェクト (非表示 if undefined)
    */
@@ -150,9 +143,6 @@ export default withIntroTypes<TaskExecuteModal>({
   //                                                                       =============
   show(): boolean {
     return this.state.status !== 'None'
-  },
-  modalClass(): string {
-    return this.state.status === 'Error' ? 'architrave task-execute-error-modal' : ''
   },
   modal(): SuModal | undefined {
     switch (this.state.status) {

--- a/frontend/src/static/app/pages/client/task-execute-modal.ts
+++ b/frontend/src/static/app/pages/client/task-execute-modal.ts
@@ -6,7 +6,7 @@ import { IntroRiotComponent, withIntroTypes } from '../../app-component-types'
 /**
  * DBFluteタスク実行ステータス。
  */
-export type TaskExecuteStatus = 'None' | 'Executing' | 'Completed'
+export type TaskExecuteStatus = 'None' | 'Executing' | 'Completed' | 'Error'
 
 // > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >
 // ^                                                                                     v
@@ -59,6 +59,17 @@ type SuModal = {
 
 /** 完了を示すモーダルダイアログ。su-modalに引き渡すオブジェクト。 */
 const COMPLETED_MODAL: SuModal = {
+  closable: true,
+  buttons: [
+    {
+      text: 'CLOSE',
+      default: true,
+    },
+  ],
+}
+
+/** 例外発生を示すモーダルダイアログ。su-modalに引き渡すオブジェクト。 */
+const ERROR_MODAL: SuModal = {
   closable: true,
   buttons: [
     {
@@ -139,6 +150,8 @@ export default withIntroTypes<TaskExecuteModal>({
         return EXECUTING_MODAL
       case 'Completed':
         return COMPLETED_MODAL
+      case 'Error':
+        return ERROR_MODAL
     }
   },
   onHide() {

--- a/frontend/src/static/app/pages/client/task-execute-modal.ts
+++ b/frontend/src/static/app/pages/client/task-execute-modal.ts
@@ -107,6 +107,12 @@ interface TaskExecuteModal extends IntroRiotComponent<Props, State> {
   show(): boolean
 
   /**
+   * Error状態用のclass属性値。
+   * @return Error状態ならclass属性値
+   */
+  errorClass(): string
+
+  /**
    * su-modal の modal 相当。
    * @return 表示するモーダルオブジェクト (非表示 if undefined)
    */
@@ -141,6 +147,9 @@ export default withIntroTypes<TaskExecuteModal>({
   //                                                                       =============
   show(): boolean {
     return this.state.status !== 'None'
+  },
+  errorClass(): string {
+    return this.state.status === 'Error' ? 'task-execute-error-tone' : ''
   },
   modal(): SuModal | undefined {
     switch (this.state.status) {


### PR DESCRIPTION
**概要**

`task-execute-modal` の異常系ハンドリングを見直しました。  
これまで一部のタスク画面では、API 例外時にモーダルが消えるだけだったり、追加 API 呼び出しの失敗で `Unexpected Frontend Error` に流れてしまうことがありました。今回、タスク実行の文脈で例外を受け止めて、`Error` 状態のモーダルを表示するようにしています。

**変更内容**

- `TaskExecuteStatus` に `Error` を追加
- API 例外時に `None` へ戻さず、`Error` 状態のモーダルを表示するよう変更
- `Documents` / `SchemaSyncCheck` / `AlterCheck` で、実行開始時や例外時に `updateContents()` を使わず、`this.update(...)` で状態更新するよう整理
- これにより、例外時の追加 API 呼び出しによる `unhandledrejection` を回避
- `Error` 時のメッセージを `Could not complete the task. Please try again.` に統一
- `Error` モーダルの UI は、正常系と同じモーダル構造を維持しつつ、色だけ既存のグローバルエラー表示に寄せて視覚的に区別する方針とした
- `replace-schema.ts` の `console.error(...)` と `schema-sync-check.ts` のデバッグ用 `console.log(...)` を削除
  - `no-console` 対応に加えて、今回の例外処理はコンソールへ残すのではなく、タスク実行結果モーダルで案内する方針に整理したため

**背景**

これまでの実装では、タスク実行 API の失敗を catch した後に別 API を呼ぶ画面があり、サーバー停止時などに `Unexpected Frontend Error` が前面に出てしまうことがありました。  
今回の変更では、タスク実行失敗はグローバルエラーではなく、そのタスク専用のモーダルで案内する方針に寄せています。

**動作確認内容**

- 正常系では従来どおり `Success` / `Failure` の結果モーダルが表示されること
- API 例外時に `Unexpected Frontend Error` ではなく、タスク実行結果モーダルが表示されること
- `ReplaceSchema` / `AlterCheck` / `Documents` / `SchemaSyncCheck` で挙動が揃っていること
- `Error` 時の見た目は、正常系と同じモーダル構造を維持しつつ、色のみ異常系として区別されていること

必要なら、このまま PR 用にもう少し短く圧縮した版も作れます。