### PR TITLE
[Riot7] schema-policy-check の api 呼び出しを動詞付きの新名に追従 #439

### DIFF
--- a/frontend/__tests__/schema-policy-check.test.ts
+++ b/frontend/__tests__/schema-policy-check.test.ts
@@ -74,14 +74,14 @@ async function flush() {
 
 beforeEach(() => {
   jest.spyOn(api, 'schemaPolicy').mockResolvedValue(baseSchemaPolicyResult)
-  jest.spyOn(api, 'clientPropbase').mockResolvedValue(baseClientPropbase)
-  jest.spyOn(api, 'latestResult').mockResolvedValue(null)
+  jest.spyOn(api, 'findClientPropbase').mockResolvedValue(baseClientPropbase)
+  jest.spyOn(api, 'findLatestTaskLog').mockResolvedValue(null)
   jest.spyOn(api, 'editSchemaPolicy').mockResolvedValue(undefined)
   jest.spyOn(api, 'deleteSchemapolicyStatement').mockResolvedValue(undefined)
   jest.spyOn(api, 'moveSchemapolicyStatement').mockResolvedValue(undefined)
   jest.spyOn(api, 'registerSchemapolicyStatement').mockResolvedValue('built statement')
   jest.spyOn(api, 'getSchemapolicyStatementSubject').mockResolvedValue(['tableName', 'alias', 'firstDate'])
-  jest.spyOn(api, 'task').mockResolvedValue({ success: true } as TaskExecuteResult)
+  jest.spyOn(api, 'executeTask').mockResolvedValue({ success: true } as TaskExecuteResult)
 })
 
 afterEach(() => {
@@ -152,7 +152,7 @@ describe('SchemaPolicyCheck 画面', () => {
     })
 
     it('成功ログがある場合は "Result: Success" (positive) が描画されること', async () => {
-      jest.spyOn(api, 'latestResult').mockResolvedValue({
+      jest.spyOn(api, 'findLatestTaskLog').mockResolvedValue({
         fileName: 'dbflute_intro_doc_success_20260510.log',
         content: 'doc task ok',
       } as LogLatestResult)
@@ -168,7 +168,7 @@ describe('SchemaPolicyCheck 画面', () => {
     })
 
     it('失敗ログがある場合は "Result: Failure" (negative) が描画されること', async () => {
-      jest.spyOn(api, 'latestResult').mockResolvedValue({
+      jest.spyOn(api, 'findLatestTaskLog').mockResolvedValue({
         fileName: 'dbflute_intro_doc_failure_20260510.log',
         content: 'doc task ng',
       } as LogLatestResult)
@@ -184,8 +184,8 @@ describe('SchemaPolicyCheck 画面', () => {
     })
 
     it('違反ありのときは SchemaPolicy 結果 HTML へのリンクが描画されること', async () => {
-      jest.spyOn(api, 'clientPropbase').mockResolvedValue({ ...baseClientPropbase, violatesSchemaPolicy: true })
-      jest.spyOn(api, 'latestResult').mockResolvedValue({
+      jest.spyOn(api, 'findClientPropbase').mockResolvedValue({ ...baseClientPropbase, violatesSchemaPolicy: true })
+      jest.spyOn(api, 'findLatestTaskLog').mockResolvedValue({
         fileName: 'dbflute_intro_doc_failure_20260510.log',
         content: 'violation content',
       } as LogLatestResult)
@@ -200,7 +200,7 @@ describe('SchemaPolicyCheck 画面', () => {
     })
 
     it('違反なしのときは SchemaPolicy 結果 HTML へのリンクは描画されないこと', async () => {
-      jest.spyOn(api, 'latestResult').mockResolvedValue({
+      jest.spyOn(api, 'findLatestTaskLog').mockResolvedValue({
         fileName: 'dbflute_intro_doc_success_20260510.log',
         content: 'ok',
       } as LogLatestResult)
@@ -328,8 +328,8 @@ describe('SchemaPolicyCheck 画面', () => {
   //                                              Doc Task
   //                                              --------
   describe('SchemaPolicyCheck (doc task) 実行', () => {
-    it('"Execute SchemaPolicyCheck" ボタンで api.task("doc") が呼ばれること', async () => {
-      const taskSpy = jest.spyOn(api, 'task')
+    it('"Execute SchemaPolicyCheck" ボタンで api.executeTask("doc") が呼ばれること', async () => {
+      const taskSpy = jest.spyOn(api, 'executeTask')
       const { container, unmount } = mountSchemaPolicyCheck()
       await flush()
 

--- a/frontend/src/static/app/pages/client/schema-policy-check/schema-policy-check.ts
+++ b/frontend/src/static/app/pages/client/schema-policy-check/schema-policy-check.ts
@@ -130,7 +130,7 @@ export default withIntroTypes<SchemaPolicyCheck>({
     }
     this.update({ executeStatus: 'Executing', executeResultMessage: 'Checking...' })
     try {
-      const data = await api.task(this.props.projectName, 'doc')
+      const data = await api.executeTask(this.props.projectName, 'doc')
       // doc task 自体の成否はモーダルメッセージに反映するが、SchemaPolicy違反の最終判定は
       // この後の loadSchemaPolicy() で取得する clientPropbase.violatesSchemaPolicy で行う
       const message = data.success ? 'Success!!' : 'Failure: You need to check violation.'
@@ -195,8 +195,8 @@ export default withIntroTypes<SchemaPolicyCheck>({
     const projectName = this.props.projectName
     const [schemaPolicy, client, latestResultData] = await Promise.all([
       api.schemaPolicy(projectName),
-      api.clientPropbase(projectName),
-      api.latestResult(projectName, 'doc'),
+      api.findClientPropbase(projectName),
+      api.findLatestTaskLog(projectName, 'doc'),
     ])
     // doc task の成否はログファイル名 (success/failure) で判定する。
     // violatesSchemaPolicy は (success/failure とは別の信号として) 違反時に


### PR DESCRIPTION
## 概要

develop ブランチの CircleCI (`npm run test`) が `FAIL __tests__/schema-policy-check.test.ts` で落ちていたため修正します。

## 原因

- PR #601 (#589 `apits_naming_first`、2026-05-26 マージ) で `api.ts` のメソッド名が動詞付きにリネームされた。
- PR #600 (#439 SchemaPolicy 画面移植、2026-05-28 マージ) の feature ブランチはリネーム前に切ったままで、SchemaPolicy 関連のソース/テストが旧名を残したまま develop にマージされた。
- ts-jest が `schema-policy-check.test.ts` をコンパイル時に型チェックして TS2769 / TS2339 で停止していた。

```
Argument of type '"clientPropbase"' is not assignable to parameter of type 'keyof Api'.
Property 'mockResolvedValue' does not exist on type 'never'.
```

`schema-policy-check.ts` の本体側も旧名のままだったが、`.riot` 経由でロードされる script 部分が webpack ビルドの厳格な型チェック対象外になっており、テストで初めて顕在化していた。

## 変更内容

旧名 → 新名の追従:

| 旧 | 新 |
| --- | --- |
| `api.task` | `api.executeTask` |
| `api.clientPropbase` | `api.findClientPropbase` |
| `api.latestResult` | `api.findLatestTaskLog` |

修正ファイル:
- `frontend/src/static/app/pages/client/schema-policy-check/schema-policy-check.ts`
- `frontend/__tests__/schema-policy-check.test.ts` (jest.spyOn のキー文字列 + テスト名コメントも追従)

## 動作確認

- ローカル `npm test` で 14/14 PASS (本 PR 修正対象の 13 + welcome 1)。

## Test plan

- [x] CircleCI の `test_and_build` が green になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)