### PR TITLE
unhandledrejection問題もろもろ解決して、ApiClient呼び出しのcatchは任意にした

### DIFF
--- a/frontend/src/static/app/api/api.ts
+++ b/frontend/src/static/app/api/api.ts
@@ -110,8 +110,21 @@ const handleError = (error: AxiosError) => {
   } else if (status >= 500) {
     header = '500 Server Error'
     messages = Object.values(response.data.messages)
+  } else if (status >= 400 && status <= 499) {
+    // Intro想定外のクライアントエラー
+    header = 'Unknown Client Error: ' + status
+    messages = Object.values(response.data.messages)
+  } else if (status >= 500 && status <= 599) {
+    // Intro想定外のサーバーエラー
+    header = 'Unknown Server Error: ' + status
+    messages = Object.values(response.data.messages)
+  } else {
+    // さらなる想定外のエラー (API呼び出しの例外ハンドリングはすべてApiClientで完結させるため)
+    header = 'Unknown Error: ' + status
+    messages = Object.values(response.data.messages)
   }
   if (header != null || messages != null) {
+    // 考慮漏れがなければ基本true
     const modalSize = validationError ? 'small' : 'large'
     triggerShowResult({ header, messages, modalSize })
   }

--- a/frontend/src/static/app/api/api.ts
+++ b/frontend/src/static/app/api/api.ts
@@ -115,7 +115,7 @@ const handleError = (error: AxiosError) => {
     const modalSize = validationError ? 'small' : 'large'
     triggerShowResult({ header, messages, modalSize })
   }
-  return Promise.reject(error)
+  return Promise.reject(error) // 画面固有の処理も付け足せるように、rejectで例外を継続
 }
 
 // IntroサーバーAPIのインスタンス準備

--- a/frontend/src/static/app/index.ts
+++ b/frontend/src/static/app/index.ts
@@ -104,14 +104,12 @@ window.addEventListener('error', (event) => {
 
 // Promiseの中でthrowされたエラーを拾うため、さらにunhandledrejectionにもEventListenerを設定。
 // 例えば、api.ts の handleError の中でthrowされた例外とかはここに来る。
+//
+// webpackのアップグレードでエラーオーバーレイ (ローカル環境用) は出るようになったが、
+// ここでのmodal表示で役割が被って二重表示になるので webpack.config.js にてOFF (2026/06/11)
 window.addEventListener('unhandledrejection', (event) => {
-  // _/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
   // ApiClientの例外、すでにmodal表示されるのでここでは表示不要なので(というか上書きしないように)処理なし。
   // これにてApiClientの呼び出しでcatch必須じゃないようにできた。 (2026/06/11)
-  //
-  // それによりエラーオーバーレイ (webpackの機能、ローカル環境用) が出るようになっていたが、
-  // 本当に想定外の例外は unhandledrejection でmodal表示するので webpack.config.js にてOFF (2026/06/11)
-  // _/_/_/_/_/_/_/_/
   // #for_now jflute AxiosErrorの判定、ちょっと曖昧なのでもっと確実にできないだろうか？ (2026/06/11)
   if (event.reason && event.reason.toString().includes('AxiosError')) {
     return

--- a/frontend/src/static/app/index.ts
+++ b/frontend/src/static/app/index.ts
@@ -85,9 +85,14 @@ if (root) {
 }
 
 // フロントエンドのグローバルエラーの監視を開始。
-// 'error' や 'unhandledrejection' の event がここに来てダイアログ表示される。
 subscribeGlobalError((msg) => {
-  // エラーを拾った際、ダイアログでエラーを表示する
+  // _/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
+  // 'error' や 'unhandledrejection' の event がここに来てダイアログ表示される。
+  // (app-events.ts の triggerGlobalError() が呼ばれるとこのコールバックに来る)
+  //
+  // result-view.riot の表示領域(modal)を使うので、すでにダイアログ表示していたら上書きなるので注意。
+  // (アプリで例外発生 → アプリでcatchしてダイアログ表示 → 再throw(これがダメ) → ここに来て上書き表示)
+  // _/_/_/_/_/_/_/_/
   triggerShowResult({ header: 'Unexpected Frontend Error', messages: [msg] })
 })
 
@@ -109,7 +114,6 @@ window.addEventListener('unhandledrejection', (event) => {
   // _/_/_/_/_/_/_/_/
   // #for_now jflute AxiosErrorの判定、ちょっと曖昧なのでもっと確実にできないだろうか？ (2026/06/11)
   if (event.reason && event.reason.toString().includes('AxiosError')) {
-    // from ApiClient
     return
   }
   // 本当に例外ハンドリング何もされていない例外がここに来てmodal表示される。

--- a/frontend/src/static/app/index.ts
+++ b/frontend/src/static/app/index.ts
@@ -100,6 +100,19 @@ window.addEventListener('error', (event) => {
 // Promiseの中でthrowされたエラーを拾うため、さらにunhandledrejectionにもEventListenerを設定。
 // 例えば、api.ts の handleError の中でthrowされた例外とかはここに来る。
 window.addEventListener('unhandledrejection', (event) => {
+  // _/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
+  // ApiClientの例外、すでにmodal表示されるのでここでは表示不要なので(というか上書きしないように)処理なし。
+  // これにてApiClientの呼び出しでcatch必須じゃないようにできた。 (2026/06/11)
+  //
+  // それによりエラーオーバーレイ (webpackの機能、ローカル環境用) が出るようになっていたが、
+  // 本当に想定外の例外は unhandledrejection でmodal表示するので webpack.config.js にてOFF (2026/06/11)
+  // _/_/_/_/_/_/_/_/
+  // #for_now jflute AxiosErrorの判定、ちょっと曖昧なのでもっと確実にできないだろうか？ (2026/06/11)
+  if (event.reason && event.reason.toString().includes('AxiosError')) {
+    // from ApiClient
+    return
+  }
+  // 本当に例外ハンドリング何もされていない例外がここに来てmodal表示される。
   // type は固定で "unhandledrejection", reason に実際throwされた例外のメッセージが入っている
   triggerGlobalError('[' + event.type + '] ' + event.reason)
 })

--- a/frontend/src/static/app/pages/create/create.ts
+++ b/frontend/src/static/app/pages/create/create.ts
@@ -173,23 +173,22 @@ export default withIntroTypes<Create>({
   //                                                                           =========
   async onMounted() {
     try {
-      const data = await api.findClassifications()
-      const classifications = this.convertClassificationsForUI(data)
+      const apiResult = await api.findClassifications()
+      const classifications = this.convertClassificationsForUI(apiResult)
       this.databaseMap = classifications.databaseMap
       this.targetDatabaseItems = classifications.targetDatabaseItems
       this.targetLanguageItems = classifications.targetLanguageItems
       this.targetContainerItems = classifications.targetContainerItems
     } catch (_) {
-      // ApiClientの例外ハンドリングをglobalで上書きしないよう(空でも)catch必須
-      // 画面固有の例外ハンドリング特になし
+      // ApiClientの例外ハンドリングで十分で何もなし。
+      // ただ、onMounted()としては後続処理をできるだけやっておきたいので空catchしておく。
     }
     try {
       // then().catch()方式だと、catch()で void | ... の union型になってしまって型エラーになるから普通try/catch
-      const data = await api.findExistingEngineVersions()
-      this.engineVersions = data.map((version) => ({ label: version, value: version, default: false }))
+      const apiResult = await api.findExistingEngineVersions()
+      this.engineVersions = apiResult.map((version) => ({ label: version, value: version, default: false }))
     } catch (_) {
-      // ApiClientの例外ハンドリングをglobalで上書きしないよう(空でも)catch必須
-      // 画面固有の例外ハンドリング特になし
+      // 同じく、後続処理をできるだけやっておきたいので空catchしておく。
     }
     this.update()
   },
@@ -247,16 +246,10 @@ export default withIntroTypes<Create>({
       testConnection: this.inputElementBy('[ref=testConnection]').checked,
     }
 
-    api
-      .createClient(body)
-      .then(() => {
-        appRoutes.main.open()
-        this.showToast(body.client.projectName)
-      })
-      .catch((error) => {
-        // ApiClientの例外ハンドリングをglobalで上書きしないよう(空でも)catch必須
-        // 画面固有の例外ハンドリング特になし
-      })
+    api.createClient(body).then(() => {
+      appRoutes.main.open()
+      this.showToast(body.client.projectName)
+    })
   },
 
   onchangeJarFile(event: InputEvent) {

--- a/frontend/src/static/app/pages/create/create.ts
+++ b/frontend/src/static/app/pages/create/create.ts
@@ -236,10 +236,15 @@ export default withIntroTypes<Create>({
       testConnection: this.inputElementBy('[ref=testConnection]').checked,
     }
 
-    api.createClient(body).then(() => {
-      appRoutes.main.open()
-      this.showToast(body.client.projectName)
-    })
+    api
+      .createClient(body)
+      .then(() => {
+        appRoutes.main.open()
+        this.showToast(body.client.projectName)
+      })
+      .catch((error) => {
+        // ApiClientのmodal表示に任せて画面固有の例外ハンドリングなし (throw終了のため空catchは必要)
+      })
   },
 
   onchangeJarFile(event: InputEvent) {

--- a/frontend/src/static/app/pages/create/create.ts
+++ b/frontend/src/static/app/pages/create/create.ts
@@ -172,14 +172,25 @@ export default withIntroTypes<Create>({
   //                                                                           Lifecycle
   //                                                                           =========
   async onMounted() {
-    const classifications = await api.findClassifications().then((data) => this.convertClassificationsForUI(data))
-    this.databaseMap = classifications.databaseMap
-    this.targetDatabaseItems = classifications.targetDatabaseItems
-    this.targetLanguageItems = classifications.targetLanguageItems
-    this.targetContainerItems = classifications.targetContainerItems
-    this.engineVersions = await api
-      .findExistingEngineVersions()
-      .then((data) => data.map((version) => ({ label: version, value: version, default: false })))
+    try {
+      const data = await api.findClassifications()
+      const classifications = this.convertClassificationsForUI(data)
+      this.databaseMap = classifications.databaseMap
+      this.targetDatabaseItems = classifications.targetDatabaseItems
+      this.targetLanguageItems = classifications.targetLanguageItems
+      this.targetContainerItems = classifications.targetContainerItems
+    } catch (_) {
+      // ApiClientの例外ハンドリングをglobalで上書きしないよう(空でも)catch必須
+      // 画面固有の例外ハンドリング特になし
+    }
+    try {
+      // then().catch()方式だと、catch()で void | ... の union型になってしまって型エラーになるから普通try/catch
+      const data = await api.findExistingEngineVersions()
+      this.engineVersions = data.map((version) => ({ label: version, value: version, default: false }))
+    } catch (_) {
+      // ApiClientの例外ハンドリングをglobalで上書きしないよう(空でも)catch必須
+      // 画面固有の例外ハンドリング特になし
+    }
     this.update()
   },
 
@@ -243,7 +254,8 @@ export default withIntroTypes<Create>({
         this.showToast(body.client.projectName)
       })
       .catch((error) => {
-        // ApiClientのmodal表示に任せて画面固有の例外ハンドリングなし (throw終了のため空catchは必要)
+        // ApiClientの例外ハンドリングをglobalで上書きしないよう(空でも)catch必須
+        // 画面固有の例外ハンドリング特になし
       })
   },
 

--- a/frontend/src/static/app/pages/welcome/welcome.ts
+++ b/frontend/src/static/app/pages/welcome/welcome.ts
@@ -228,15 +228,15 @@ export default withIntroTypes<Welcome>({
       this.targetLanguageItems = classifications.targetLanguageItems
       this.targetContainerItems = classifications.targetContainerItems
     } catch (_) {
-      // ApiClientの例外ハンドリングをglobalで上書きしないよう(空でも)catch必須
-      // 画面固有の例外ハンドリング特になし
+      // ApiClientの例外ハンドリングで十分で何もなし。
+      // ただ、onMounted()としては後続処理をできるだけやっておきたいので空catchしておく。
     }
     try {
+      // then().catch()方式だと、catch()で void | ... の union型になってしまって型エラーになるから普通try/catch
       const data = await api.findEngineLatestVersion()
       this.latestVersion = data.latestReleaseVersion
     } catch (_) {
-      // ApiClientの例外ハンドリングをglobalで上書きしないよう(空でも)catch必須
-      // 画面固有の例外ハンドリング特になし
+      // 同じく、後続処理をできるだけやっておきたいので空catchしておく。
     }
     this.update()
   },
@@ -316,10 +316,6 @@ export default withIntroTypes<Welcome>({
       .then(() => {
         appRoutes.main.open()
         this.showToast(body.client.projectName)
-      })
-      .catch((error) => {
-        // ApiClientの例外ハンドリングをglobalで上書きしないよう(空でも)catch必須
-        // 画面固有の例外ハンドリング特になし
       })
       .finally(() => {
         this.suLoading(false)

--- a/frontend/src/static/app/pages/welcome/welcome.ts
+++ b/frontend/src/static/app/pages/welcome/welcome.ts
@@ -306,6 +306,9 @@ export default withIntroTypes<Welcome>({
         appRoutes.main.open()
         this.showToast(body.client.projectName)
       })
+      .catch((error) => {
+        // ApiClientのmodal表示に任せて画面固有の例外ハンドリングなし (throw終了のため空catchは必要)
+      })
       .finally(() => {
         this.suLoading(false)
       })

--- a/frontend/src/static/app/pages/welcome/welcome.ts
+++ b/frontend/src/static/app/pages/welcome/welcome.ts
@@ -220,13 +220,24 @@ export default withIntroTypes<Welcome>({
   //                                                                           Lifecycle
   //                                                                           =========
   async onMounted() {
-    const classifications = await api.findClassifications().then((data) => this.convertClassificationsForUI(data))
-    const latestVersion = await api.findEngineLatestVersion().then((data) => data.latestReleaseVersion)
-    this.databaseMap = classifications.databaseMap
-    this.targetDatabaseItems = classifications.targetDatabaseItems
-    this.targetLanguageItems = classifications.targetLanguageItems
-    this.targetContainerItems = classifications.targetContainerItems
-    this.latestVersion = latestVersion
+    try {
+      const data = await api.findClassifications()
+      const classifications = this.convertClassificationsForUI(data)
+      this.databaseMap = classifications.databaseMap
+      this.targetDatabaseItems = classifications.targetDatabaseItems
+      this.targetLanguageItems = classifications.targetLanguageItems
+      this.targetContainerItems = classifications.targetContainerItems
+    } catch (_) {
+      // ApiClientの例外ハンドリングをglobalで上書きしないよう(空でも)catch必須
+      // 画面固有の例外ハンドリング特になし
+    }
+    try {
+      const data = await api.findEngineLatestVersion()
+      this.latestVersion = data.latestReleaseVersion
+    } catch (_) {
+      // ApiClientの例外ハンドリングをglobalで上書きしないよう(空でも)catch必須
+      // 画面固有の例外ハンドリング特になし
+    }
     this.update()
   },
 
@@ -307,7 +318,8 @@ export default withIntroTypes<Welcome>({
         this.showToast(body.client.projectName)
       })
       .catch((error) => {
-        // ApiClientのmodal表示に任せて画面固有の例外ハンドリングなし (throw終了のため空catchは必要)
+        // ApiClientの例外ハンドリングをglobalで上書きしないよう(空でも)catch必須
+        // 画面固有の例外ハンドリング特になし
       })
       .finally(() => {
         this.suLoading(false)

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -17,6 +17,18 @@ module.exports = {
     static: {
       directory: './src/static',
     },
+    client: {
+      overlay: {
+        // _/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/
+        // ApiClient呼び出しでcatch必須を避けるためunhandledrejectionで例外内容次第でmodal上書き回避しているが、
+        // (ローカル環境で)余計なエラーオーバーレイが出てしまうのでデフォルトではOFFにしておく。
+        // それ以外の不意の例外はunhandledrejectionでmodal表示されるので、オーバーレイがなくても問題ないはず。
+        // もしわからないエラーが出たら、一時的にtrueにしてオーバーレイを見るようにするくらいでOKかと。
+        //  by jflute (2026/06/11)
+        // _/_/_/_/_/_/_/_/
+        runtimeErrors: false,
+      },
+    },
   },
   module: {
     rules: [


### PR DESCRIPTION
# 概要
以下のイシュー対応:
[Riot7] サーバーサイドのバリデーションエラー後のダイアログでunhandledrejection #603

